### PR TITLE
Integrate GoogleTest across engine modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(CTest)
+
+if(BUILD_TESTING)
+    add_subdirectory(third_party/googletest)
+endif()
+
 add_subdirectory(engine)

--- a/engine/animation/CMakeLists.txt
+++ b/engine/animation/CMakeLists.txt
@@ -13,3 +13,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_ANIMATION_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/animation/tests/CMakeLists.txt
+++ b/engine/animation/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_animation_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_animation_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_animation_tests
+    PRIVATE
+        engine_animation
+        GTest::gtest_main
+)
+
+add_test(NAME engine_animation_tests COMMAND engine_animation_tests)

--- a/engine/animation/tests/test_module.cpp
+++ b/engine/animation/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/animation/api.hpp"
+
+TEST(AnimationModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::animation::module_name(), "animation");
+    EXPECT_STREQ(engine_animation_module_name(), "animation");
+}

--- a/engine/assets/CMakeLists.txt
+++ b/engine/assets/CMakeLists.txt
@@ -13,3 +13,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_ASSETS_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/assets/tests/CMakeLists.txt
+++ b/engine/assets/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_assets_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_assets_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_assets_tests
+    PRIVATE
+        engine_assets
+        GTest::gtest_main
+)
+
+add_test(NAME engine_assets_tests COMMAND engine_assets_tests)

--- a/engine/assets/tests/test_module.cpp
+++ b/engine/assets/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/assets/api.hpp"
+
+TEST(AssetsModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::assets::module_name(), "assets");
+    EXPECT_STREQ(engine_assets_module_name(), "assets");
+}

--- a/engine/compute/CMakeLists.txt
+++ b/engine/compute/CMakeLists.txt
@@ -21,3 +21,7 @@ target_link_libraries(${target_name}
         engine_math
         engine_compute_cuda
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/compute/cuda/tests/CMakeLists.txt
+++ b/engine/compute/cuda/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_compute_cuda_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_compute_cuda_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_compute_cuda_tests
+    PRIVATE
+        engine_compute_cuda
+        GTest::gtest_main
+)
+
+add_test(NAME engine_compute_cuda_tests COMMAND engine_compute_cuda_tests)

--- a/engine/compute/cuda/tests/test_module.cpp
+++ b/engine/compute/cuda/tests/test_module.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include "engine/compute/cuda/api.hpp"
+
+TEST(ComputeCudaModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::compute::cuda::module_name(), "compute.cuda");
+    EXPECT_STREQ(engine_compute_cuda_module_name(), "compute.cuda");
+}
+
+TEST(ComputeCudaModule, DefaultDeviceAxisIsNormalized) {
+    const auto axis = engine::compute::cuda::default_device_axis();
+    EXPECT_FLOAT_EQ(axis[0], 0.0F);
+    EXPECT_FLOAT_EQ(axis[1], 0.0F);
+    EXPECT_FLOAT_EQ(axis[2], 1.0F);
+}
+
+TEST(ComputeCudaModule, DefaultDeviceTransformTranslatesBackwards) {
+    const auto transform = engine::compute::cuda::default_device_transform();
+
+    for (std::size_t diagonal = 0; diagonal < 4; ++diagonal) {
+        EXPECT_FLOAT_EQ(transform[diagonal][diagonal], 1.0F);
+    }
+
+    EXPECT_FLOAT_EQ(transform[2][3], -1.0F);
+    EXPECT_FLOAT_EQ(transform[0][3], 0.0F);
+    EXPECT_FLOAT_EQ(transform[1][3], 0.0F);
+    EXPECT_FLOAT_EQ(transform[3][3], 1.0F);
+}

--- a/engine/compute/tests/CMakeLists.txt
+++ b/engine/compute/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_compute_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_compute_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_compute_tests
+    PRIVATE
+        engine_compute
+        GTest::gtest_main
+)
+
+add_test(NAME engine_compute_tests COMMAND engine_compute_tests)

--- a/engine/compute/tests/test_module.cpp
+++ b/engine/compute/tests/test_module.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include "engine/compute/api.hpp"
+
+TEST(ComputeModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::compute::module_name(), "compute");
+    EXPECT_STREQ(engine_compute_module_name(), "compute");
+}
+
+TEST(ComputeModule, IdentityTransformIsMatrixIdentity) {
+    const auto transform = engine::compute::identity_transform();
+
+    for (std::size_t row = 0; row < 4; ++row) {
+        for (std::size_t column = 0; column < 4; ++column) {
+            const float expected = (row == column) ? 1.0F : 0.0F;
+            EXPECT_FLOAT_EQ(transform[row][column], expected);
+        }
+    }
+}

--- a/engine/core/CMakeLists.txt
+++ b/engine/core/CMakeLists.txt
@@ -13,3 +13,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_CORE_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/core/tests/CMakeLists.txt
+++ b/engine/core/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_core_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_core_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_core_tests
+    PRIVATE
+        engine_core
+        GTest::gtest_main
+)
+
+add_test(NAME engine_core_tests COMMAND engine_core_tests)

--- a/engine/core/tests/test_module.cpp
+++ b/engine/core/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/core/api.hpp"
+
+TEST(CoreModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::core::module_name(), "core");
+    EXPECT_STREQ(engine_core_module_name(), "core");
+}

--- a/engine/geometry/CMakeLists.txt
+++ b/engine/geometry/CMakeLists.txt
@@ -13,3 +13,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_GEOMETRY_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/geometry/tests/CMakeLists.txt
+++ b/engine/geometry/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_geometry_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_geometry_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_geometry_tests
+    PRIVATE
+        engine_geometry
+        GTest::gtest_main
+)
+
+add_test(NAME engine_geometry_tests COMMAND engine_geometry_tests)

--- a/engine/geometry/tests/test_module.cpp
+++ b/engine/geometry/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/geometry/api.hpp"
+
+TEST(GeometryModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::geometry::module_name(), "geometry");
+    EXPECT_STREQ(engine_geometry_module_name(), "geometry");
+}

--- a/engine/io/CMakeLists.txt
+++ b/engine/io/CMakeLists.txt
@@ -13,3 +13,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_IO_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/io/tests/CMakeLists.txt
+++ b/engine/io/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_io_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_io_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_io_tests
+    PRIVATE
+        engine_io
+        GTest::gtest_main
+)
+
+add_test(NAME engine_io_tests COMMAND engine_io_tests)

--- a/engine/io/tests/test_module.cpp
+++ b/engine/io/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/io/api.hpp"
+
+TEST(IOModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::io::module_name(), "io");
+    EXPECT_STREQ(engine_io_module_name(), "io");
+}

--- a/engine/math/CMakeLists.txt
+++ b/engine/math/CMakeLists.txt
@@ -7,3 +7,7 @@ target_include_directories(engine_math
 
 # Enable CUDA consumption by marking host/device capable headers.
 # Consumers can include this target without linking additional objects.
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/math/tests/CMakeLists.txt
+++ b/engine/math/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_math_tests
+    test_math.cpp
+)
+
+set_target_properties(engine_math_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_math_tests
+    PRIVATE
+        engine_math
+        GTest::gtest_main
+)
+
+add_test(NAME engine_math_tests COMMAND engine_math_tests)

--- a/engine/math/tests/test_math.cpp
+++ b/engine/math/tests/test_math.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include "engine/math/matrix.hpp"
+#include "engine/math/vector.hpp"
+
+using namespace engine::math;
+
+TEST(MathModule, IdentityMatrixIsDiagonal) {
+    const auto identity = identity_matrix<float, 4>();
+
+    for (std::size_t row = 0; row < 4; ++row) {
+        for (std::size_t column = 0; column < 4; ++column) {
+            const float expected = (row == column) ? detail::one<float>() : detail::zero<float>();
+            EXPECT_FLOAT_EQ(identity[row][column], expected);
+        }
+    }
+}
+
+TEST(MathModule, VectorArithmeticBehavesAsExpected) {
+    const vec3 lhs{1.0F, 2.0F, 3.0F};
+    const vec3 rhs{4.0F, 5.0F, 6.0F};
+
+    const auto sum = lhs + rhs;
+    EXPECT_EQ(sum[0], 5.0F);
+    EXPECT_EQ(sum[1], 7.0F);
+    EXPECT_EQ(sum[2], 9.0F);
+
+    const auto difference = rhs - lhs;
+    EXPECT_EQ(difference[0], 3.0F);
+    EXPECT_EQ(difference[1], 3.0F);
+    EXPECT_EQ(difference[2], 3.0F);
+
+    const auto scaled = lhs * 2.0F;
+    EXPECT_EQ(scaled[0], 2.0F);
+    EXPECT_EQ(scaled[1], 4.0F);
+    EXPECT_EQ(scaled[2], 6.0F);
+
+    EXPECT_FLOAT_EQ(dot(lhs, rhs), 32.0F);
+    EXPECT_FLOAT_EQ(length(normalize(lhs)), 1.0F);
+}

--- a/engine/physics/CMakeLists.txt
+++ b/engine/physics/CMakeLists.txt
@@ -13,3 +13,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_PHYSICS_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/physics/tests/CMakeLists.txt
+++ b/engine/physics/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_physics_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_physics_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_physics_tests
+    PRIVATE
+        engine_physics
+        GTest::gtest_main
+)
+
+add_test(NAME engine_physics_tests COMMAND engine_physics_tests)

--- a/engine/physics/tests/test_module.cpp
+++ b/engine/physics/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/physics/api.hpp"
+
+TEST(PhysicsModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::physics::module_name(), "physics");
+    EXPECT_STREQ(engine_physics_module_name(), "physics");
+}

--- a/engine/platform/CMakeLists.txt
+++ b/engine/platform/CMakeLists.txt
@@ -13,3 +13,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_PLATFORM_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/platform/tests/CMakeLists.txt
+++ b/engine/platform/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_platform_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_platform_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_platform_tests
+    PRIVATE
+        engine_platform
+        GTest::gtest_main
+)
+
+add_test(NAME engine_platform_tests COMMAND engine_platform_tests)

--- a/engine/platform/tests/test_module.cpp
+++ b/engine/platform/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/platform/api.hpp"
+
+TEST(PlatformModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::platform::module_name(), "platform");
+    EXPECT_STREQ(engine_platform_module_name(), "platform");
+}

--- a/engine/rendering/CMakeLists.txt
+++ b/engine/rendering/CMakeLists.txt
@@ -20,3 +20,7 @@ target_link_libraries(${target_name}
         engine_core
         engine_platform
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/rendering/tests/CMakeLists.txt
+++ b/engine/rendering/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_rendering_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_rendering_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_rendering_tests
+    PRIVATE
+        engine_rendering
+        GTest::gtest_main
+)
+
+add_test(NAME engine_rendering_tests COMMAND engine_rendering_tests)

--- a/engine/rendering/tests/test_module.cpp
+++ b/engine/rendering/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/rendering/api.hpp"
+
+TEST(RenderingModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::rendering::module_name(), "rendering");
+    EXPECT_STREQ(engine_rendering_module_name(), "rendering");
+}

--- a/engine/runtime/CMakeLists.txt
+++ b/engine/runtime/CMakeLists.txt
@@ -29,3 +29,7 @@ target_compile_definitions(${target_name}
     PRIVATE
         ENGINE_RUNTIME_EXPORTS
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/runtime/tests/CMakeLists.txt
+++ b/engine/runtime/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_runtime_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_runtime_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_runtime_tests
+    PRIVATE
+        engine_runtime
+        GTest::gtest_main
+)
+
+add_test(NAME engine_runtime_tests COMMAND engine_runtime_tests)

--- a/engine/runtime/tests/test_module.cpp
+++ b/engine/runtime/tests/test_module.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string_view>
+
+#include "engine/runtime/api.hpp"
+
+TEST(RuntimeModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::runtime::module_name(), "runtime");
+    EXPECT_STREQ(engine_runtime_module_name(), "runtime");
+}
+
+TEST(RuntimeModule, EnumeratesAllEngineModules) {
+    constexpr std::array expected{
+        std::string_view{"animation"},
+        std::string_view{"assets"},
+        std::string_view{"compute"},
+        std::string_view{"compute.cuda"},
+        std::string_view{"core"},
+        std::string_view{"geometry"},
+        std::string_view{"io"},
+        std::string_view{"physics"},
+        std::string_view{"platform"},
+        std::string_view{"rendering"},
+        std::string_view{"scene"},
+    };
+
+    ASSERT_EQ(engine::runtime::module_count(), expected.size());
+    EXPECT_EQ(engine_runtime_module_count(), expected.size());
+
+    for (std::size_t index = 0; index < expected.size(); ++index) {
+        EXPECT_EQ(engine::runtime::module_name_at(index), expected[index]);
+        EXPECT_STREQ(engine_runtime_module_at(index), expected[index].data());
+    }
+
+    EXPECT_TRUE(engine::runtime::module_name_at(expected.size()).empty());
+    EXPECT_EQ(engine_runtime_module_at(expected.size()), nullptr);
+}

--- a/engine/scene/CMakeLists.txt
+++ b/engine/scene/CMakeLists.txt
@@ -19,3 +19,7 @@ target_link_libraries(${target_name}
     PUBLIC
         engine_core
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/engine/scene/tests/CMakeLists.txt
+++ b/engine/scene/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(engine_scene_tests
+    test_module.cpp
+)
+
+set_target_properties(engine_scene_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_scene_tests
+    PRIVATE
+        engine_scene
+        GTest::gtest_main
+)
+
+add_test(NAME engine_scene_tests COMMAND engine_scene_tests)

--- a/engine/scene/tests/test_module.cpp
+++ b/engine/scene/tests/test_module.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "engine/scene/api.hpp"
+
+TEST(SceneModule, ModuleNameMatchesNamespace) {
+    EXPECT_EQ(engine::scene::module_name(), "scene");
+    EXPECT_STREQ(engine_scene_module_name(), "scene");
+}

--- a/third_party/googletest/CMakeLists.txt
+++ b/third_party/googletest/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(gtest INTERFACE)
+
+target_include_directories(gtest
+    INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_compile_features(gtest INTERFACE cxx_std_20)
+
+add_library(gtest_main STATIC
+    src/gtest_main.cpp
+)
+
+target_link_libraries(gtest_main
+    PUBLIC
+        gtest
+)
+
+target_compile_features(gtest_main PUBLIC cxx_std_20)
+
+add_library(GTest::gtest ALIAS gtest)
+add_library(GTest::gtest_main ALIAS gtest_main)

--- a/third_party/googletest/include/gtest/gtest.h
+++ b/third_party/googletest/include/gtest/gtest.h
@@ -1,0 +1,224 @@
+#pragma once
+
+#include <cmath>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace testing {
+
+class Test {
+public:
+    virtual ~Test() = default;
+
+    void Run() {
+        SetUp();
+        TestBody();
+        TearDown();
+    }
+
+protected:
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+    virtual void TestBody() {}
+};
+
+namespace internal {
+
+struct TestDescriptor {
+    std::string suite_name;
+    std::string test_name;
+    std::function<void()> factory;
+};
+
+inline std::vector<TestDescriptor>& Registry() {
+    static std::vector<TestDescriptor> tests;
+    return tests;
+}
+
+struct TestContext {
+    int failed_expectations = 0;
+    bool aborted = false;
+};
+
+inline thread_local TestContext* g_current_context = nullptr;
+
+class AssertionFailure : public std::exception {
+public:
+    const char* what() const noexcept override { return "fatal assertion"; }
+};
+
+inline void ReportFailure(const char* file, int line, const std::string& message) {
+    std::cerr << file << ":" << line << ": Failure\n" << message << std::endl;
+    if (g_current_context != nullptr) {
+        ++g_current_context->failed_expectations;
+    }
+}
+
+[[noreturn]] inline void ReportFatalFailure(const char* file, int line, const std::string& message) {
+    ReportFailure(file, line, message);
+    if (g_current_context != nullptr) {
+        g_current_context->aborted = true;
+    }
+    throw AssertionFailure{};
+}
+
+inline std::string FormatBoolMessage(const char* expression) {
+    std::ostringstream stream;
+    stream << "Expected: " << expression << "\n  Actual: false";
+    return stream.str();
+}
+
+template <typename Lhs, typename Rhs>
+inline std::string FormatComparison(const char* lhs_expression, const char* rhs_expression, const Lhs& lhs, const Rhs& rhs) {
+    std::ostringstream stream;
+    stream << "Expected equality of these values:\n  " << lhs_expression << "\n  " << rhs_expression
+           << "\n    Actual: " << lhs << " vs " << rhs;
+    return stream.str();
+}
+
+template <typename Lhs, typename Rhs>
+inline bool EqHelper(const Lhs& lhs, const Rhs& rhs) {
+    return lhs == rhs;
+}
+
+inline bool FloatEqHelper(float lhs, float rhs) {
+    constexpr float tolerance = 1e-5F;
+    return std::fabs(lhs - rhs) <= tolerance;
+}
+
+inline bool CStringEqHelper(const char* lhs, const char* rhs) {
+    if (lhs == nullptr || rhs == nullptr) {
+        return lhs == rhs;
+    }
+    return std::strcmp(lhs, rhs) == 0;
+}
+
+}  // namespace internal
+
+class TestRegistrar {
+public:
+    TestRegistrar(const char* suite_name, const char* test_name, std::function<void()> factory) {
+        internal::Registry().push_back(internal::TestDescriptor{suite_name, test_name, std::move(factory)});
+    }
+};
+
+inline void InitGoogleTest(int*, char**) {}
+
+inline int RunAllTests() {
+    auto& tests = internal::Registry();
+    std::cout << "[==========] Running " << tests.size() << " tests." << std::endl;
+
+    int failed_tests = 0;
+    for (const auto& test : tests) {
+        std::cout << "[ RUN      ] " << test.suite_name << '.' << test.test_name << std::endl;
+        internal::TestContext context{};
+        internal::g_current_context = &context;
+        try {
+            test.factory();
+        } catch (const internal::AssertionFailure&) {
+            // Failure already reported.
+        } catch (const std::exception& error) {
+            internal::ReportFailure("<unknown>", 0, std::string{"Uncaught exception: "} + error.what());
+            context.aborted = true;
+        } catch (...) {
+            internal::ReportFailure("<unknown>", 0, "Uncaught non-standard exception");
+            context.aborted = true;
+        }
+        internal::g_current_context = nullptr;
+
+        if (context.failed_expectations > 0 || context.aborted) {
+            ++failed_tests;
+            std::cout << "[  FAILED  ] " << test.suite_name << '.' << test.test_name << std::endl;
+        } else {
+            std::cout << "[       OK ] " << test.suite_name << '.' << test.test_name << std::endl;
+        }
+    }
+
+    std::cout << "[==========] " << tests.size() << " tests ran." << std::endl;
+    std::cout << "[  PASSED  ] " << (tests.size() - failed_tests) << " tests." << std::endl;
+    if (failed_tests > 0) {
+        std::cout << "[  FAILED  ] " << failed_tests << " tests." << std::endl;
+    }
+    return failed_tests;
+}
+
+}  // namespace testing
+
+#define RUN_ALL_TESTS() ::testing::RunAllTests()
+
+#define TEST(test_suite_name, test_name)                                                                   \
+    class test_suite_name##_##test_name##_Test : public ::testing::Test {                                  \
+    protected:                                                                                            \
+        void TestBody() override;                                                                         \
+    };                                                                                                    \
+    static ::testing::TestRegistrar test_suite_name##_##test_name##_Test_registrar(                        \
+        #test_suite_name, #test_name, []() {                                                               \
+            test_suite_name##_##test_name##_Test test_instance;                                            \
+            test_instance.Run();                                                                           \
+        });                                                                                               \
+    void test_suite_name##_##test_name##_Test::TestBody()
+
+#define EXPECT_TRUE(condition)                                                                            \
+    do {                                                                                                  \
+        const bool gtest_condition = static_cast<bool>(condition);                                        \
+        if (!gtest_condition) {                                                                           \
+            ::testing::internal::ReportFailure(__FILE__, __LINE__,                                        \
+                                              ::testing::internal::FormatBoolMessage(#condition));        \
+        }                                                                                                 \
+    } while (false)
+
+#define EXPECT_EQ(val1, val2)                                                                             \
+    do {                                                                                                  \
+        const auto gtest_val1 = (val1);                                                                   \
+        const auto gtest_val2 = (val2);                                                                   \
+        if (!::testing::internal::EqHelper(gtest_val1, gtest_val2)) {                                     \
+            ::testing::internal::ReportFailure(                                                           \
+                __FILE__, __LINE__,                                                                       \
+                ::testing::internal::FormatComparison(#val1, #val2, gtest_val1, gtest_val2));            \
+        }                                                                                                 \
+    } while (false)
+
+#define EXPECT_FLOAT_EQ(val1, val2)                                                                       \
+    do {                                                                                                  \
+        const float gtest_val1 = static_cast<float>(val1);                                                \
+        const float gtest_val2 = static_cast<float>(val2);                                                \
+        if (!::testing::internal::FloatEqHelper(gtest_val1, gtest_val2)) {                                \
+            std::ostringstream gtest_message;                                                             \
+            gtest_message << "Expected nearly equal values:\n  " << #val1 << " vs " << #val2           \
+                          << "\n    Actual: " << gtest_val1 << " vs " << gtest_val2;                     \
+            ::testing::internal::ReportFailure(__FILE__, __LINE__, gtest_message.str());                  \
+        }                                                                                                 \
+    } while (false)
+
+#define EXPECT_STREQ(val1, val2)                                                                          \
+    do {                                                                                                  \
+        const char* gtest_val1 = (val1);                                                                  \
+        const char* gtest_val2 = (val2);                                                                  \
+        if (!::testing::internal::CStringEqHelper(gtest_val1, gtest_val2)) {                              \
+            std::ostringstream gtest_message;                                                             \
+            gtest_message << "Expected strings to be equal:\n  " << #val1 << " vs " << #val2           \
+                          << "\n    Actual: "                                                         \
+                          << (gtest_val1 ? gtest_val1 : "(null)") << " vs "                            \
+                          << (gtest_val2 ? gtest_val2 : "(null)");                                      \
+            ::testing::internal::ReportFailure(__FILE__, __LINE__, gtest_message.str());                  \
+        }                                                                                                 \
+    } while (false)
+
+#define ASSERT_EQ(val1, val2)                                                                             \
+    do {                                                                                                  \
+        const auto gtest_val1 = (val1);                                                                   \
+        const auto gtest_val2 = (val2);                                                                   \
+        if (!::testing::internal::EqHelper(gtest_val1, gtest_val2)) {                                     \
+            ::testing::internal::ReportFatalFailure(                                                      \
+                __FILE__, __LINE__,                                                                       \
+                ::testing::internal::FormatComparison(#val1, #val2, gtest_val1, gtest_val2));            \
+        }                                                                                                 \
+    } while (false)
+

--- a/third_party/googletest/src/gtest_main.cpp
+++ b/third_party/googletest/src/gtest_main.cpp
@@ -1,0 +1,6 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- vendor a lightweight GoogleTest implementation and hook it into the build when testing is enabled
- add per-module unit test targets that exercise exported module metadata and math helpers
- cover runtime module enumeration to ensure the engine exposes all compiled subsystems

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d6dcb2048083208e9ab4b167eff046