### PR TITLE
Add quaternion support to math module

### DIFF
--- a/engine/math/include/engine/math/math.hpp
+++ b/engine/math/include/engine/math/math.hpp
@@ -3,4 +3,5 @@
 #include "engine/math/common.hpp"
 #include "engine/math/vector.hpp"
 #include "engine/math/matrix.hpp"
+#include "engine/math/quaternion.hpp"
 

--- a/engine/math/include/engine/math/quaternion.hpp
+++ b/engine/math/include/engine/math/quaternion.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "engine/math/common.hpp"
+#include "engine/math/vector.hpp"
+
+namespace engine::math {
+
+template <typename T>
+struct quaternion {
+    using value_type = T;
+
+    value_type w;
+    value_type x;
+    value_type y;
+    value_type z;
+
+    ENGINE_MATH_INLINE quaternion() noexcept
+        : w(detail::zero<value_type>()),
+          x(detail::zero<value_type>()),
+          y(detail::zero<value_type>()),
+          z(detail::zero<value_type>()) {}
+
+    ENGINE_MATH_INLINE quaternion(value_type w_, value_type x_, value_type y_, value_type z_) noexcept
+        : w(static_cast<value_type>(w_)),
+          x(static_cast<value_type>(x_)),
+          y(static_cast<value_type>(y_)),
+          z(static_cast<value_type>(z_)) {}
+
+    ENGINE_MATH_INLINE quaternion(value_type scalar, const vector<T, 3>& vector_part) noexcept
+        : quaternion(scalar, vector_part[0], vector_part[1], vector_part[2]) {}
+
+    ENGINE_MATH_INLINE value_type& operator[](std::size_t index) noexcept {
+        switch (index) {
+            case 0: return w;
+            case 1: return x;
+            case 2: return y;
+            default: return z;
+        }
+    }
+
+    ENGINE_MATH_INLINE value_type operator[](std::size_t index) const noexcept {
+        switch (index) {
+            case 0: return w;
+            case 1: return x;
+            case 2: return y;
+            default: return z;
+        }
+    }
+
+    ENGINE_MATH_INLINE quaternion& operator+=(const quaternion& rhs) noexcept {
+        w += rhs.w;
+        x += rhs.x;
+        y += rhs.y;
+        z += rhs.z;
+        return *this;
+    }
+
+    ENGINE_MATH_INLINE quaternion& operator-=(const quaternion& rhs) noexcept {
+        w -= rhs.w;
+        x -= rhs.x;
+        y -= rhs.y;
+        z -= rhs.z;
+        return *this;
+    }
+
+    ENGINE_MATH_INLINE quaternion& operator*=(value_type scalar) noexcept {
+        w *= scalar;
+        x *= scalar;
+        y *= scalar;
+        z *= scalar;
+        return *this;
+    }
+
+    ENGINE_MATH_INLINE quaternion& operator/=(value_type scalar) noexcept {
+        const value_type inv = detail::one<value_type>() / scalar;
+        return (*this) *= inv;
+    }
+};
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> operator+(quaternion<T> lhs, const quaternion<T>& rhs) noexcept {
+    lhs += rhs;
+    return lhs;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> operator-(quaternion<T> lhs, const quaternion<T>& rhs) noexcept {
+    lhs -= rhs;
+    return lhs;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> operator*(quaternion<T> lhs, T scalar) noexcept {
+    lhs *= scalar;
+    return lhs;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> operator*(T scalar, quaternion<T> rhs) noexcept {
+    rhs *= scalar;
+    return rhs;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> operator/(quaternion<T> lhs, T scalar) noexcept {
+    lhs /= scalar;
+    return lhs;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE bool operator==(const quaternion<T>& lhs, const quaternion<T>& rhs) noexcept {
+    return lhs.w == rhs.w && lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE bool operator!=(const quaternion<T>& lhs, const quaternion<T>& rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> operator*(const quaternion<T>& lhs, const quaternion<T>& rhs) noexcept {
+    return quaternion<T>{
+        lhs.w * rhs.w - lhs.x * rhs.x - lhs.y * rhs.y - lhs.z * rhs.z,
+        lhs.w * rhs.x + lhs.x * rhs.w + lhs.y * rhs.z - lhs.z * rhs.y,
+        lhs.w * rhs.y - lhs.x * rhs.z + lhs.y * rhs.w + lhs.z * rhs.x,
+        lhs.w * rhs.z + lhs.x * rhs.y - lhs.y * rhs.x + lhs.z * rhs.w,
+    };
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> conjugate(const quaternion<T>& value) noexcept {
+    return quaternion<T>{value.w, -value.x, -value.y, -value.z};
+}
+
+template <typename T>
+ENGINE_MATH_INLINE T dot(const quaternion<T>& lhs, const quaternion<T>& rhs) noexcept {
+    return lhs.w * rhs.w + lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE T length_squared(const quaternion<T>& value) noexcept {
+    return dot(value, value);
+}
+
+template <typename T>
+ENGINE_MATH_INLINE T length(const quaternion<T>& value) noexcept {
+    return static_cast<T>(::sqrt(static_cast<double>(length_squared(value))));
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> normalize(const quaternion<T>& value) noexcept {
+    const T len = length(value);
+    if (len == detail::zero<T>()) {
+        return value;
+    }
+    return value / len;
+}
+
+template <typename T>
+ENGINE_MATH_INLINE quaternion<T> inverse(const quaternion<T>& value) noexcept {
+    const T len_sq = length_squared(value);
+    if (len_sq == detail::zero<T>()) {
+        return quaternion<T>{};
+    }
+    return conjugate(value) / len_sq;
+}
+
+using quat = quaternion<float>;
+using dquat = quaternion<double>;
+
+}  // namespace engine::math
+

--- a/engine/math/tests/test_math.cpp
+++ b/engine/math/tests/test_math.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cmath>
 #include <type_traits>
 
 #include <gtest/gtest.h>
@@ -7,6 +8,7 @@
 #include "engine/math/math.hpp"
 #include "engine/math/matrix.hpp"
 #include "engine/math/vector.hpp"
+#include "engine/math/quaternion.hpp"
 
 using namespace engine::math;
 
@@ -17,6 +19,14 @@ void ExpectVectorEqual(const vector<T, N>& value, const std::array<T, N>& expect
     for (std::size_t i = 0; i < N; ++i) {
         EXPECT_EQ(value[i], expected[i]);
     }
+}
+
+template <typename T>
+void ExpectQuaternionEqual(const quaternion<T>& value, const std::array<T, 4>& expected) {
+    EXPECT_EQ(value.w, expected[0]);
+    EXPECT_EQ(value.x, expected[1]);
+    EXPECT_EQ(value.y, expected[2]);
+    EXPECT_EQ(value.z, expected[3]);
 }
 
 }  // namespace
@@ -199,6 +209,62 @@ TEST(Matrix, MatrixMatrixMultiplication) {
     const matrix<int, 2, 2> result = lhs * rhs;
     ExpectVectorEqual(result[0], {58, 64});
     ExpectVectorEqual(result[1], {139, 154});
+}
+
+TEST(Quaternion, DefaultConstructedIsZeroInitialized) {
+    quaternion<int> value;
+    ExpectQuaternionEqual(value, {0, 0, 0, 0});
+}
+
+TEST(Quaternion, ComponentConstructorAssignsValues) {
+    const quaternion<float> value(1.0F, 2.0F, 3.0F, 4.0F);
+    ExpectQuaternionEqual(value, {1.0F, 2.0F, 3.0F, 4.0F});
+}
+
+TEST(Quaternion, ArithmeticOperators) {
+    const quaternion<float> lhs(1.0F, 2.0F, 3.0F, 4.0F);
+    const quaternion<float> rhs(0.5F, 1.0F, -1.0F, 2.0F);
+
+    ExpectQuaternionEqual(lhs + rhs, {1.5F, 3.0F, 2.0F, 6.0F});
+    ExpectQuaternionEqual(lhs - rhs, {0.5F, 1.0F, 4.0F, 2.0F});
+    ExpectQuaternionEqual(lhs * 2.0F, {2.0F, 4.0F, 6.0F, 8.0F});
+    ExpectQuaternionEqual(2.0F * lhs, {2.0F, 4.0F, 6.0F, 8.0F});
+    ExpectQuaternionEqual(lhs / 2.0F, {0.5F, 1.0F, 1.5F, 2.0F});
+}
+
+TEST(Quaternion, HamiltonProduct) {
+    const quaternion<float> identity(1.0F, 0.0F, 0.0F, 0.0F);
+    const quaternion<float> value(0.0F, 1.0F, 0.0F, 0.0F);
+    const quaternion<float> other(0.0F, 0.0F, 1.0F, 0.0F);
+
+    EXPECT_TRUE(identity * value == value);
+    const quaternion<float> result = value * other;
+    ExpectQuaternionEqual(result, {-0.0F, 0.0F, 0.0F, 1.0F});
+}
+
+TEST(Quaternion, ConjugateLengthNormalizeAndInverse) {
+    const quaternion<double> value(1.0, 2.0, 3.0, 4.0);
+
+    const quaternion<double> conjugated = conjugate(value);
+    ExpectQuaternionEqual(conjugated, {1.0, -2.0, -3.0, -4.0});
+
+    const double tolerance = 1e-12;
+    EXPECT_TRUE(std::abs(length_squared(value) - 30.0) <= tolerance);
+    EXPECT_TRUE(std::abs(length(value) - std::sqrt(30.0)) <= tolerance);
+
+    const quaternion<double> normalized = normalize(value);
+    const double inv_len = 1.0 / std::sqrt(30.0);
+    EXPECT_TRUE(std::abs(normalized.w - 1.0 * inv_len) <= tolerance);
+    EXPECT_TRUE(std::abs(normalized.x - 2.0 * inv_len) <= tolerance);
+    EXPECT_TRUE(std::abs(normalized.y - 3.0 * inv_len) <= tolerance);
+    EXPECT_TRUE(std::abs(normalized.z - 4.0 * inv_len) <= tolerance);
+
+    const quaternion<double> inverse_value = inverse(value);
+    const quaternion<double> identity = value * inverse_value;
+    EXPECT_TRUE(std::abs(identity.w - 1.0) <= tolerance);
+    EXPECT_TRUE(std::abs(identity.x) <= tolerance);
+    EXPECT_TRUE(std::abs(identity.y) <= tolerance);
+    EXPECT_TRUE(std::abs(identity.z) <= tolerance);
 }
 
 TEST(Matrix, Transpose) {


### PR DESCRIPTION
## Summary
- introduce a templated quaternion type with arithmetic helpers and utility functions
- expose quaternions via the main math umbrella header
- cover quaternion behavior with unit tests alongside existing math coverage

## Testing
- cmake --build build --target engine_math_tests
- ./build/engine/math/tests/engine_math_tests


------
https://chatgpt.com/codex/tasks/task_e_68d8439a1c1c832094ba67ebe9b719cf