### PR TITLE
Add geometric shape utilities and tests

### DIFF
--- a/engine/geometry/CMakeLists.txt
+++ b/engine/geometry/CMakeLists.txt
@@ -2,11 +2,17 @@ set(target_name engine_geometry)
 
 add_library(${target_name}
     src/api.cpp
+    src/shapes.cpp
 )
 
 target_include_directories(${target_name}
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(${target_name}
+    PUBLIC
+        engine_math
 )
 
 target_compile_definitions(${target_name}

--- a/engine/geometry/include/engine/geometry/shapes.hpp
+++ b/engine/geometry/include/engine/geometry/shapes.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstddef>
+
+#include "engine/geometry/api.hpp"
+#include "engine/math/matrix.hpp"
+#include "engine/math/vector.hpp"
+
+namespace engine::geometry {
+
+struct aabb {
+    math::vec3 min;
+    math::vec3 max;
+};
+
+[[nodiscard]] math::vec3 center(const aabb& box) noexcept;
+[[nodiscard]] math::vec3 size(const aabb& box) noexcept;
+[[nodiscard]] math::vec3 extent(const aabb& box) noexcept;
+[[nodiscard]] float surface_area(const aabb& box) noexcept;
+[[nodiscard]] float volume(const aabb& box) noexcept;
+[[nodiscard]] bool contains(const aabb& box, const math::vec3& point) noexcept;
+
+struct obb {
+    math::vec3 center;
+    math::vec3 half_sizes;
+    math::mat3 orientation;
+};
+
+[[nodiscard]] math::vec3 size(const obb& box) noexcept;
+[[nodiscard]] math::vec3 extent(const obb& box) noexcept;
+[[nodiscard]] bool contains(const obb& box, const math::vec3& point) noexcept;
+[[nodiscard]] aabb bounding_aabb(const obb& box) noexcept;
+
+struct sphere {
+    math::vec3 center;
+    float radius;
+};
+
+[[nodiscard]] float surface_area(const sphere& s) noexcept;
+[[nodiscard]] float volume(const sphere& s) noexcept;
+[[nodiscard]] bool contains(const sphere& s, const math::vec3& point) noexcept;
+
+struct plane {
+    math::vec3 normal;
+    float distance;
+};
+
+[[nodiscard]] float signed_distance(const plane& p, const math::vec3& point) noexcept;
+[[nodiscard]] math::vec3 project_point(const plane& p, const math::vec3& point) noexcept;
+[[nodiscard]] bool contains(const plane& p, const math::vec3& point, float epsilon = 1e-4f) noexcept;
+
+struct ray {
+    math::vec3 origin;
+    math::vec3 direction;
+};
+
+[[nodiscard]] math::vec3 point_at(const ray& r, float t) noexcept;
+
+struct segment {
+    math::vec3 start;
+    math::vec3 end;
+};
+
+[[nodiscard]] math::vec3 direction(const segment& s) noexcept;
+[[nodiscard]] float length(const segment& s) noexcept;
+[[nodiscard]] math::vec3 point_at(const segment& s, float t) noexcept;
+
+struct line {
+    math::vec3 point;
+    math::vec3 direction;
+};
+
+[[nodiscard]] math::vec3 point_at(const line& l, float t) noexcept;
+[[nodiscard]] math::vec3 project_point(const line& l, const math::vec3& point) noexcept;
+
+struct ellipsoid {
+    math::vec3 center;
+    math::vec3 radii;
+    math::mat3 orientation;
+};
+
+[[nodiscard]] float volume(const ellipsoid& e) noexcept;
+[[nodiscard]] bool contains(const ellipsoid& e, const math::vec3& point) noexcept;
+
+struct triangle {
+    math::vec3 a;
+    math::vec3 b;
+    math::vec3 c;
+};
+
+[[nodiscard]] math::vec3 normal(const triangle& t) noexcept;
+[[nodiscard]] math::vec3 unit_normal(const triangle& t) noexcept;
+[[nodiscard]] float area(const triangle& t) noexcept;
+[[nodiscard]] math::vec3 centroid(const triangle& t) noexcept;
+
+struct cylinder {
+    math::vec3 center;
+    math::vec3 axis;
+    float radius;
+    float half_height;
+};
+
+[[nodiscard]] math::vec3 axis_direction(const cylinder& c) noexcept;
+[[nodiscard]] math::vec3 top_center(const cylinder& c) noexcept;
+[[nodiscard]] math::vec3 bottom_center(const cylinder& c) noexcept;
+[[nodiscard]] float volume(const cylinder& c) noexcept;
+[[nodiscard]] float lateral_surface_area(const cylinder& c) noexcept;
+[[nodiscard]] float surface_area(const cylinder& c) noexcept;
+[[nodiscard]] bool contains(const cylinder& c, const math::vec3& point) noexcept;
+
+}  // namespace engine::geometry
+

--- a/engine/geometry/src/shapes.cpp
+++ b/engine/geometry/src/shapes.cpp
@@ -1,0 +1,256 @@
+#include "engine/geometry/shapes.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <numbers>
+
+namespace engine::geometry {
+namespace {
+
+[[nodiscard]] constexpr float half() noexcept { return 0.5f; }
+
+[[nodiscard]] constexpr float two() noexcept { return 2.0f; }
+
+}  // namespace
+
+math::vec3 center(const aabb& box) noexcept {
+    return (box.min + box.max) * half();
+}
+
+math::vec3 size(const aabb& box) noexcept {
+    return box.max - box.min;
+}
+
+math::vec3 extent(const aabb& box) noexcept {
+    return size(box) * half();
+}
+
+float surface_area(const aabb& box) noexcept {
+    const math::vec3 s = size(box);
+    return two() * (s[0] * s[1] + s[1] * s[2] + s[0] * s[2]);
+}
+
+float volume(const aabb& box) noexcept {
+    const math::vec3 s = size(box);
+    return s[0] * s[1] * s[2];
+}
+
+bool contains(const aabb& box, const math::vec3& point) noexcept {
+    for (std::size_t i = 0; i < 3; ++i) {
+        if (point[i] < box.min[i] || point[i] > box.max[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+math::vec3 size(const obb& box) noexcept {
+    return box.half_sizes * two();
+}
+
+math::vec3 extent(const obb& box) noexcept {
+    return box.half_sizes;
+}
+
+bool contains(const obb& box, const math::vec3& point) noexcept {
+    const math::vec3 relative = point - box.center;
+    const math::mat3 inverse_orientation = math::transpose(box.orientation);
+    const math::vec3 local = inverse_orientation * relative;
+
+    for (std::size_t i = 0; i < 3; ++i) {
+        if (std::fabs(local[i]) > box.half_sizes[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+aabb bounding_aabb(const obb& box) noexcept {
+    std::array<math::vec3, 8> corners{};
+    std::size_t index = 0U;
+
+    for (int x = -1; x <= 1; x += 2) {
+        for (int y = -1; y <= 1; y += 2) {
+            for (int z = -1; z <= 1; z += 2) {
+                const math::vec3 local_corner{
+                    static_cast<float>(x) * box.half_sizes[0],
+                    static_cast<float>(y) * box.half_sizes[1],
+                    static_cast<float>(z) * box.half_sizes[2],
+                };
+                corners[index++] = box.center + box.orientation * local_corner;
+            }
+        }
+    }
+
+    math::vec3 min_corner{
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max(),
+    };
+
+    math::vec3 max_corner{
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest(),
+    };
+
+    for (const auto& corner : corners) {
+        for (std::size_t i = 0; i < 3; ++i) {
+            min_corner[i] = std::min(min_corner[i], corner[i]);
+            max_corner[i] = std::max(max_corner[i], corner[i]);
+        }
+    }
+
+    return aabb{min_corner, max_corner};
+}
+
+float surface_area(const sphere& s) noexcept {
+    return static_cast<float>(4.0) * std::numbers::pi_v<float> * s.radius * s.radius;
+}
+
+float volume(const sphere& s) noexcept {
+    return static_cast<float>(4.0 / 3.0) * std::numbers::pi_v<float> * s.radius * s.radius * s.radius;
+}
+
+bool contains(const sphere& s, const math::vec3& point) noexcept {
+    const math::vec3 offset = point - s.center;
+    return math::length_squared(offset) <= s.radius * s.radius;
+}
+
+float signed_distance(const plane& p, const math::vec3& point) noexcept {
+    return math::dot(p.normal, point) + p.distance;
+}
+
+math::vec3 project_point(const plane& p, const math::vec3& point) noexcept {
+    const float denom = math::length_squared(p.normal);
+    if (denom == 0.0f) {
+        return point;
+    }
+    const float dist = signed_distance(p, point);
+    return point - p.normal * (dist / denom);
+}
+
+bool contains(const plane& p, const math::vec3& point, float epsilon) noexcept {
+    return std::fabs(signed_distance(p, point)) <= epsilon;
+}
+
+math::vec3 point_at(const ray& r, float t) noexcept {
+    return r.origin + r.direction * t;
+}
+
+math::vec3 direction(const segment& s) noexcept {
+    return s.end - s.start;
+}
+
+float length(const segment& s) noexcept {
+    return math::length(direction(s));
+}
+
+math::vec3 point_at(const segment& s, float t) noexcept {
+    return s.start + direction(s) * t;
+}
+
+math::vec3 point_at(const line& l, float t) noexcept {
+    return l.point + l.direction * t;
+}
+
+math::vec3 project_point(const line& l, const math::vec3& point) noexcept {
+    const float denom = math::length_squared(l.direction);
+    if (denom == 0.0f) {
+        return l.point;
+    }
+    const math::vec3 offset = point - l.point;
+    const float t = math::dot(offset, l.direction) / denom;
+    return point_at(l, t);
+}
+
+float volume(const ellipsoid& e) noexcept {
+    return static_cast<float>(4.0 / 3.0) * std::numbers::pi_v<float> * e.radii[0] * e.radii[1] * e.radii[2];
+}
+
+bool contains(const ellipsoid& e, const math::vec3& point) noexcept {
+    const math::vec3 relative = point - e.center;
+    const math::mat3 inverse_orientation = math::transpose(e.orientation);
+    const math::vec3 local = inverse_orientation * relative;
+
+    float sum = 0.0f;
+    for (std::size_t i = 0; i < 3; ++i) {
+        if (e.radii[i] == 0.0f) {
+            if (local[i] != 0.0f) {
+                return false;
+            }
+            continue;
+        }
+        const float scaled = local[i] / e.radii[i];
+        sum += scaled * scaled;
+    }
+
+    return sum <= 1.0f + std::numeric_limits<float>::epsilon();
+}
+
+math::vec3 normal(const triangle& t) noexcept {
+    return math::cross(t.b - t.a, t.c - t.a);
+}
+
+math::vec3 unit_normal(const triangle& t) noexcept {
+    return math::normalize(normal(t));
+}
+
+float area(const triangle& t) noexcept {
+    return half() * math::length(normal(t));
+}
+
+math::vec3 centroid(const triangle& t) noexcept {
+    return (t.a + t.b + t.c) / static_cast<float>(3.0);
+}
+
+math::vec3 axis_direction(const cylinder& c) noexcept {
+    const float len = math::length(c.axis);
+    if (len == 0.0f) {
+        return math::vec3{0.0f};
+    }
+    return c.axis / len;
+}
+
+math::vec3 top_center(const cylinder& c) noexcept {
+    return c.center + axis_direction(c) * c.half_height;
+}
+
+math::vec3 bottom_center(const cylinder& c) noexcept {
+    return c.center - axis_direction(c) * c.half_height;
+}
+
+float volume(const cylinder& c) noexcept {
+    const float height = c.half_height * two();
+    return std::numbers::pi_v<float> * c.radius * c.radius * height;
+}
+
+float lateral_surface_area(const cylinder& c) noexcept {
+    const float height = c.half_height * two();
+    return two() * std::numbers::pi_v<float> * c.radius * height;
+}
+
+float surface_area(const cylinder& c) noexcept {
+    return lateral_surface_area(c) + two() * std::numbers::pi_v<float> * c.radius * c.radius;
+}
+
+bool contains(const cylinder& c, const math::vec3& point) noexcept {
+    const math::vec3 axis_dir = axis_direction(c);
+    if (math::length_squared(axis_dir) == 0.0f) {
+        return false;
+    }
+
+    const math::vec3 relative = point - c.center;
+    const float height = math::dot(relative, axis_dir);
+    if (height < -c.half_height || height > c.half_height) {
+        return false;
+    }
+
+    const math::vec3 radial = relative - axis_dir * height;
+    return math::length_squared(radial) <= c.radius * c.radius;
+}
+
+}  // namespace engine::geometry
+

--- a/engine/geometry/tests/CMakeLists.txt
+++ b/engine/geometry/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(engine_geometry_tests
     test_module.cpp
+    test_shapes.cpp
 )
 
 set_target_properties(engine_geometry_tests PROPERTIES

--- a/engine/geometry/tests/test_shapes.cpp
+++ b/engine/geometry/tests/test_shapes.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <numbers>
+
+#include "engine/geometry/shapes.hpp"
+
+using engine::geometry::aabb;
+using engine::geometry::bounding_aabb;
+using engine::math::mat3;
+using engine::math::vec3;
+
+namespace {
+
+void expect_vec3_eq(const vec3& actual, const vec3& expected) {
+    EXPECT_FLOAT_EQ(actual[0], expected[0]);
+    EXPECT_FLOAT_EQ(actual[1], expected[1]);
+    EXPECT_FLOAT_EQ(actual[2], expected[2]);
+}
+
+}  // namespace
+
+TEST(Aabb, ComputesDerivedQuantities) {
+    const aabb box{vec3{-1.0f, 0.0f, 1.0f}, vec3{3.0f, 6.0f, 5.0f}};
+
+    const vec3 expected_center{1.0f, 3.0f, 3.0f};
+    expect_vec3_eq(engine::geometry::center(box), expected_center);
+
+    const vec3 expected_size{4.0f, 6.0f, 4.0f};
+    expect_vec3_eq(engine::geometry::size(box), expected_size);
+    expect_vec3_eq(engine::geometry::extent(box), expected_size * 0.5f);
+
+    EXPECT_FLOAT_EQ(engine::geometry::surface_area(box), 128.0f);
+    EXPECT_FLOAT_EQ(engine::geometry::volume(box), 96.0f);
+
+    const vec3 inside_point{0.0f, 3.0f, 3.0f};
+    const vec3 outside_point{4.1f, 3.0f, 3.0f};
+    EXPECT_TRUE(engine::geometry::contains(box, inside_point));
+    EXPECT_TRUE(!engine::geometry::contains(box, outside_point));
+}
+
+TEST(Obb, ContainsAndBoundingBox) {
+    const float angle = std::numbers::pi_v<float> * 0.25f;
+    const mat3 orientation{
+        std::cos(angle), -std::sin(angle), 0.0f,
+        std::sin(angle), std::cos(angle), 0.0f,
+        0.0f, 0.0f, 1.0f,
+    };
+
+    const engine::geometry::obb box{
+        vec3{0.0f, 0.0f, 0.0f},
+        vec3{1.0f, 2.0f, 0.5f},
+        orientation,
+    };
+
+    const vec3 local_point{0.5f, 0.5f, 0.0f};
+    const vec3 inside = box.center + box.orientation * local_point;
+    EXPECT_TRUE(engine::geometry::contains(box, inside));
+
+    const vec3 outside = box.center + box.orientation * vec3{2.5f, 0.0f, 0.0f};
+    EXPECT_TRUE(!engine::geometry::contains(box, outside));
+
+    const aabb bounds = bounding_aabb(box);
+    EXPECT_TRUE(std::fabs(bounds.min[0] + 2.1213205f) <= 1e-5f);
+    EXPECT_TRUE(std::fabs(bounds.min[1] + 2.1213205f) <= 1e-5f);
+    EXPECT_FLOAT_EQ(bounds.min[2], -0.5f);
+    EXPECT_TRUE(std::fabs(bounds.max[0] - 2.1213205f) <= 1e-5f);
+    EXPECT_TRUE(std::fabs(bounds.max[1] - 2.1213205f) <= 1e-5f);
+    EXPECT_FLOAT_EQ(bounds.max[2], 0.5f);
+}
+
+TEST(Sphere, BasicMetrics) {
+    const engine::geometry::sphere s{vec3{1.0f, -1.0f, 0.0f}, 2.0f};
+
+    EXPECT_FLOAT_EQ(engine::geometry::surface_area(s), 16.0f * std::numbers::pi_v<float>);
+    EXPECT_FLOAT_EQ(engine::geometry::volume(s), (32.0f / 3.0f) * std::numbers::pi_v<float>);
+    const vec3 interior{1.0f, 1.0f, 0.0f};
+    const vec3 exterior{1.0f, -1.0f, 3.1f};
+    EXPECT_TRUE(engine::geometry::contains(s, interior));
+    EXPECT_TRUE(!engine::geometry::contains(s, exterior));
+}
+
+TEST(Plane, SignedDistanceAndProjection) {
+    const engine::geometry::plane p{vec3{0.0f, 1.0f, 0.0f}, -2.0f};
+
+    EXPECT_FLOAT_EQ(engine::geometry::signed_distance(p, vec3{0.0f, 2.0f, 0.0f}), 0.0f);
+    EXPECT_FLOAT_EQ(engine::geometry::signed_distance(p, vec3{0.0f, 5.0f, 0.0f}), 3.0f);
+
+    const vec3 projected = engine::geometry::project_point(p, vec3{1.0f, 5.0f, -1.0f});
+    EXPECT_FLOAT_EQ(projected[1], 2.0f);
+    EXPECT_TRUE(engine::geometry::contains(p, projected));
+    const vec3 offset_point{0.0f, 2.1f, 0.0f};
+    EXPECT_TRUE(!engine::geometry::contains(p, offset_point, 1e-2f));
+}
+
+TEST(Ray, PointAtDistance) {
+    const engine::geometry::ray r{vec3{0.0f, 0.0f, 0.0f}, vec3{1.0f, 2.0f, 0.0f}};
+    const vec3 expected{2.0f, 4.0f, 0.0f};
+    expect_vec3_eq(engine::geometry::point_at(r, 2.0f), expected);
+}
+
+TEST(Segment, LengthAndInterpolation) {
+    const engine::geometry::segment s{vec3{0.0f, 0.0f, 0.0f}, vec3{3.0f, 4.0f, 0.0f}};
+    EXPECT_FLOAT_EQ(engine::geometry::length(s), 5.0f);
+    const vec3 midpoint{1.5f, 2.0f, 0.0f};
+    expect_vec3_eq(engine::geometry::point_at(s, 0.5f), midpoint);
+}
+
+TEST(Line, Projection) {
+    const engine::geometry::line l{vec3{0.0f, 0.0f, 0.0f}, vec3{0.0f, 1.0f, 0.0f}};
+    const vec3 projected = engine::geometry::project_point(l, vec3{2.0f, 3.0f, -1.0f});
+    expect_vec3_eq(projected, vec3{0.0f, 3.0f, 0.0f});
+
+    const engine::geometry::line degenerate_line{vec3{1.0f, 2.0f, 3.0f}, vec3{0.0f, 0.0f, 0.0f}};
+    expect_vec3_eq(engine::geometry::project_point(degenerate_line, vec3{5.0f, -1.0f, 2.0f}), degenerate_line.point);
+}
+
+TEST(Ellipsoid, ContainsAndVolume) {
+    const float angle = std::numbers::pi_v<float> * 0.5f;
+    const mat3 orientation{
+        std::cos(angle), -std::sin(angle), 0.0f,
+        std::sin(angle), std::cos(angle), 0.0f,
+        0.0f, 0.0f, 1.0f,
+    };
+
+    const engine::geometry::ellipsoid e{
+        vec3{0.0f, 0.0f, 0.0f},
+        vec3{2.0f, 1.0f, 0.5f},
+        orientation,
+    };
+
+    EXPECT_FLOAT_EQ(engine::geometry::volume(e), (4.0f / 3.0f) * std::numbers::pi_v<float>);
+
+    const vec3 inside = e.center + e.orientation * vec3{1.0f, 0.0f, 0.0f};
+    const vec3 outside_point{3.0f, 0.0f, 0.0f};
+    EXPECT_TRUE(engine::geometry::contains(e, inside));
+    EXPECT_TRUE(!engine::geometry::contains(e, outside_point));
+}
+
+TEST(Triangle, AreaNormalAndCentroid) {
+    const engine::geometry::triangle t{vec3{0.0f, 0.0f, 0.0f}, vec3{1.0f, 0.0f, 0.0f}, vec3{0.0f, 2.0f, 0.0f}};
+
+    expect_vec3_eq(engine::geometry::normal(t), vec3{0.0f, 0.0f, 2.0f});
+    expect_vec3_eq(engine::geometry::unit_normal(t), vec3{0.0f, 0.0f, 1.0f});
+    EXPECT_FLOAT_EQ(engine::geometry::area(t), 1.0f);
+    expect_vec3_eq(engine::geometry::centroid(t), vec3{1.0f / 3.0f, 2.0f / 3.0f, 0.0f});
+}
+
+TEST(Cylinder, AxisDerivedValuesAndContainment) {
+    const engine::geometry::cylinder c{vec3{0.0f, 0.0f, 0.0f}, vec3{0.0f, 0.0f, 2.0f}, 1.0f, 2.0f};
+
+    expect_vec3_eq(engine::geometry::axis_direction(c), vec3{0.0f, 0.0f, 1.0f});
+    expect_vec3_eq(engine::geometry::top_center(c), vec3{0.0f, 0.0f, 2.0f});
+    expect_vec3_eq(engine::geometry::bottom_center(c), vec3{0.0f, 0.0f, -2.0f});
+
+    EXPECT_FLOAT_EQ(engine::geometry::volume(c), 4.0f * std::numbers::pi_v<float>);
+    EXPECT_FLOAT_EQ(engine::geometry::lateral_surface_area(c), 8.0f * std::numbers::pi_v<float>);
+    EXPECT_FLOAT_EQ(engine::geometry::surface_area(c), 10.0f * std::numbers::pi_v<float>);
+
+    const vec3 radial_inside{0.5f, 0.0f, 1.0f};
+    const vec3 radial_outside{1.1f, 0.0f, 0.0f};
+    const vec3 origin{0.0f, 0.0f, 0.0f};
+    EXPECT_TRUE(engine::geometry::contains(c, radial_inside));
+    EXPECT_TRUE(!engine::geometry::contains(c, radial_outside));
+    EXPECT_TRUE(!engine::geometry::contains(engine::geometry::cylinder{origin, vec3{0.0f}, 1.0f, 1.0f}, origin));
+}
+


### PR DESCRIPTION
## Summary
- add a geometry shapes public header covering AABB, OBB, sphere, plane, ray, segment, line, ellipsoid, triangle, and cylinder utilities
- implement the supporting calculations in a new source file and link the geometry library against the math interface
- extend the geometry test suite with thorough shape coverage and register the new test translation unit with CMake

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d8465c080c8320b819a9ce2c54043b