### PR TITLE
Implement optional-based geometry property registry

### DIFF
--- a/engine/geometry/CMakeLists.txt
+++ b/engine/geometry/CMakeLists.txt
@@ -2,6 +2,7 @@ set(target_name engine_geometry)
 
 add_library(${target_name}
     src/api.cpp
+    src/property_registry.cpp
     src/shapes/aabb.cpp
     src/shapes/cylinder.cpp
     src/shapes/ellipsoid.cpp

--- a/engine/geometry/README.md
+++ b/engine/geometry/README.md
@@ -1,4 +1,5 @@
 # engine/geometry
 
 This directory collects the C++ engine source tree, the geometry subsystem for meshes, primitives, and spatial algorithms.
+In addition to the spatial primitives, it now exposes the property registry that tracks per-element attributes without relying on exceptions, making it suitable for downstream mesh processing tools.
 Future additions should place additional contributions to the geometry subsystem for meshes, primitives, and spatial algorithms here to keep related work easy to discover.

--- a/engine/geometry/include/engine/geometry/README.md
+++ b/engine/geometry/include/engine/geometry/README.md
@@ -1,4 +1,5 @@
 # engine/geometry/include/engine/geometry
 
 This directory collects the C++ engine source tree, the geometry subsystem for meshes, primitives, and spatial algorithms, public headers defining the subsystem API.
+The newly added `property_registry.hpp` header contains the type-erased registry that manages mesh and point-set attributes with optional-based discovery instead of throwing exceptions.
 Future additions should place additional contributions to public headers defining the subsystem API here to keep related work easy to discover.

--- a/engine/geometry/include/engine/geometry/property_registry.hpp
+++ b/engine/geometry/include/engine/geometry/property_registry.hpp
@@ -1,0 +1,387 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <typeindex>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace engine::geometry {
+
+using PropertyId = std::size_t;
+
+class PropertyRegistry;
+
+namespace detail {
+
+class PropertyStorageBase {
+public:
+    explicit PropertyStorageBase(std::string name) : name_(std::move(name)) {}
+    virtual ~PropertyStorageBase() = default;
+
+    PropertyStorageBase(const PropertyStorageBase&) = delete;
+    PropertyStorageBase& operator=(const PropertyStorageBase&) = delete;
+
+    [[nodiscard]] const std::string& name() const noexcept { return name_; }
+
+    [[nodiscard]] virtual std::unique_ptr<PropertyStorageBase> clone() const = 0;
+
+    virtual void reserve(std::size_t n) = 0;
+    virtual void resize(std::size_t n) = 0;
+    virtual void shrink_to_fit() = 0;
+    virtual void push_back() = 0;
+    virtual void swap(std::size_t i0, std::size_t i1) = 0;
+
+    [[nodiscard]] virtual std::type_index type() const noexcept = 0;
+
+protected:
+    std::string name_;
+};
+
+template <class T>
+class PropertyStorage final : public PropertyStorageBase {
+public:
+    PropertyStorage(std::string name, T default_value)
+        : PropertyStorageBase(std::move(name)), data_(), default_(std::move(default_value))
+    {
+    }
+
+    PropertyStorage(const PropertyStorage& other)
+        : PropertyStorageBase(other.name()), data_(other.data_), default_(other.default_)
+    {
+    }
+
+    PropertyStorage& operator=(const PropertyStorage& other)
+    {
+        if (this != &other)
+        {
+            name_ = other.name_;
+            data_ = other.data_;
+            default_ = other.default_;
+        }
+        return *this;
+    }
+
+    [[nodiscard]] std::unique_ptr<PropertyStorageBase> clone() const override
+    {
+        return std::make_unique<PropertyStorage<T>>(*this);
+    }
+
+    void reserve(std::size_t n) override { data_.reserve(n); }
+    void resize(std::size_t n) override { data_.resize(n, default_); }
+    void shrink_to_fit() override { data_.shrink_to_fit(); }
+    void push_back() override { data_.push_back(default_); }
+
+    void swap(std::size_t i0, std::size_t i1) override
+    {
+        using std::swap;
+        swap(data_[i0], data_[i1]);
+    }
+
+    [[nodiscard]] std::type_index type() const noexcept override { return typeid(T); }
+
+    [[nodiscard]] std::vector<T>& data() noexcept { return data_; }
+    [[nodiscard]] const std::vector<T>& data() const noexcept { return data_; }
+    [[nodiscard]] const T& default_value() const noexcept { return default_; }
+
+private:
+    std::vector<T> data_;
+    T default_;
+};
+
+} // namespace detail
+
+template <class T>
+class PropertyBuffer;
+
+template <class T>
+class ConstPropertyBuffer;
+
+class PropertyRegistry {
+public:
+    PropertyRegistry() = default;
+    ~PropertyRegistry() = default;
+
+    PropertyRegistry(const PropertyRegistry& other);
+    PropertyRegistry(PropertyRegistry&&) noexcept = default;
+    PropertyRegistry& operator=(const PropertyRegistry& other);
+    PropertyRegistry& operator=(PropertyRegistry&&) noexcept = default;
+
+    [[nodiscard]] std::size_t size() const noexcept { return size_; }
+    [[nodiscard]] std::size_t property_count() const noexcept { return storages_.size(); }
+
+    [[nodiscard]] std::vector<std::string> property_names() const;
+
+    void clear();
+    void reserve(std::size_t n);
+    void resize(std::size_t n);
+    void shrink_to_fit();
+    void push_back();
+    void swap(std::size_t i0, std::size_t i1);
+
+    [[nodiscard]] bool contains(std::string_view name) const;
+    [[nodiscard]] std::optional<PropertyId> find(std::string_view name) const;
+
+    template <class T>
+    [[nodiscard]] std::optional<PropertyBuffer<T>> add(std::string name, T default_value = T());
+
+    template <class T>
+    [[nodiscard]] std::optional<PropertyBuffer<T>> get(std::string_view name);
+
+    template <class T>
+    [[nodiscard]] std::optional<ConstPropertyBuffer<T>> get(std::string_view name) const;
+
+    template <class T>
+    [[nodiscard]] std::optional<PropertyBuffer<T>> get(PropertyId id);
+
+    template <class T>
+    [[nodiscard]] std::optional<ConstPropertyBuffer<T>> get(PropertyId id) const;
+
+    template <class T>
+    [[nodiscard]] PropertyBuffer<T> get_or_add(std::string name, T default_value = T());
+
+    template <class T>
+    bool remove(PropertyBuffer<T>& handle);
+
+    bool remove(PropertyId id);
+
+private:
+    [[nodiscard]] detail::PropertyStorageBase* storage(PropertyId id) noexcept;
+    [[nodiscard]] const detail::PropertyStorageBase* storage(PropertyId id) const noexcept;
+
+    template <class T>
+    [[nodiscard]] detail::PropertyStorage<T>* storage(PropertyId id) noexcept;
+
+    template <class T>
+    [[nodiscard]] const detail::PropertyStorage<T>* storage(PropertyId id) const noexcept;
+
+    std::vector<std::unique_ptr<detail::PropertyStorageBase>> storages_;
+    std::size_t size_{0};
+};
+
+template <class T>
+class PropertyBuffer {
+public:
+    PropertyBuffer() = default;
+
+    [[nodiscard]] PropertyId id() const noexcept { return id_; }
+    [[nodiscard]] const std::string& name() const noexcept
+    {
+        assert(storage_ != nullptr);
+        return storage_->name();
+    }
+    [[nodiscard]] explicit operator bool() const noexcept { return storage_ != nullptr; }
+
+    [[nodiscard]] std::vector<T>& vector() const noexcept
+    {
+        assert(storage_ != nullptr);
+        return storage_->data();
+    }
+
+    [[nodiscard]] decltype(auto) operator[](std::size_t index) const
+    {
+        assert(storage_ != nullptr);
+        assert(index < storage_->data().size());
+        return storage_->data()[index];
+    }
+
+    [[nodiscard]] std::span<T> span() const noexcept requires (!std::is_same_v<T, bool>)
+    {
+        assert(storage_ != nullptr);
+        return std::span<T>(storage_->data());
+    }
+
+    [[nodiscard]] const T* data() const noexcept requires (!std::is_same_v<T, bool>)
+    {
+        assert(storage_ != nullptr);
+        return storage_->data().data();
+    }
+
+    void reset() noexcept
+    {
+        storage_ = nullptr;
+        id_ = static_cast<PropertyId>(-1);
+    }
+
+private:
+    friend class PropertyRegistry;
+
+    PropertyBuffer(PropertyId id, detail::PropertyStorage<T>* storage) : storage_(storage), id_(id) {}
+
+    detail::PropertyStorage<T>* storage_{nullptr};
+    PropertyId id_{static_cast<PropertyId>(-1)};
+};
+
+template <class T>
+class ConstPropertyBuffer {
+public:
+    ConstPropertyBuffer() = default;
+
+    [[nodiscard]] PropertyId id() const noexcept { return id_; }
+    [[nodiscard]] const std::string& name() const noexcept
+    {
+        assert(storage_ != nullptr);
+        return storage_->name();
+    }
+    [[nodiscard]] explicit operator bool() const noexcept { return storage_ != nullptr; }
+
+    [[nodiscard]] const std::vector<T>& vector() const noexcept
+    {
+        assert(storage_ != nullptr);
+        return storage_->data();
+    }
+
+    [[nodiscard]] decltype(auto) operator[](std::size_t index) const
+    {
+        assert(storage_ != nullptr);
+        assert(index < storage_->data().size());
+        return storage_->data()[index];
+    }
+
+    [[nodiscard]] std::span<const T> span() const noexcept requires (!std::is_same_v<T, bool>)
+    {
+        assert(storage_ != nullptr);
+        return std::span<const T>(storage_->data());
+    }
+
+    [[nodiscard]] const T* data() const noexcept requires (!std::is_same_v<T, bool>)
+    {
+        assert(storage_ != nullptr);
+        return storage_->data().data();
+    }
+
+private:
+    friend class PropertyRegistry;
+
+    ConstPropertyBuffer(PropertyId id, const detail::PropertyStorage<T>* storage)
+        : storage_(storage), id_(id)
+    {
+    }
+
+    const detail::PropertyStorage<T>* storage_{nullptr};
+    PropertyId id_{static_cast<PropertyId>(-1)};
+};
+
+template <class T>
+detail::PropertyStorage<T>* PropertyRegistry::storage(PropertyId id) noexcept
+{
+    auto* base = storage(id);
+    if (base == nullptr || base->type() != typeid(T))
+    {
+        return nullptr;
+    }
+    return static_cast<detail::PropertyStorage<T>*>(base);
+}
+
+template <class T>
+const detail::PropertyStorage<T>* PropertyRegistry::storage(PropertyId id) const noexcept
+{
+    auto* base = storage(id);
+    if (base == nullptr || base->type() != typeid(T))
+    {
+        return nullptr;
+    }
+    return static_cast<const detail::PropertyStorage<T>*>(base);
+}
+
+template <class T>
+std::optional<PropertyBuffer<T>> PropertyRegistry::add(std::string name, T default_value)
+{
+    if (find(name).has_value())
+    {
+        return std::nullopt;
+    }
+
+    auto storage = std::make_unique<detail::PropertyStorage<T>>(std::move(name), std::move(default_value));
+    storage->resize(size_);
+    auto* raw = storage.get();
+    storages_.push_back(std::move(storage));
+    return PropertyBuffer<T>(storages_.size() - 1U, raw);
+}
+
+template <class T>
+std::optional<PropertyBuffer<T>> PropertyRegistry::get(std::string_view name)
+{
+    if (auto id = find(name))
+    {
+        return get<T>(*id);
+    }
+    return std::nullopt;
+}
+
+template <class T>
+std::optional<ConstPropertyBuffer<T>> PropertyRegistry::get(std::string_view name) const
+{
+    if (auto id = find(name))
+    {
+        return get<T>(*id);
+    }
+    return std::nullopt;
+}
+
+template <class T>
+std::optional<PropertyBuffer<T>> PropertyRegistry::get(PropertyId id)
+{
+    if (auto* typed = storage<T>(id))
+    {
+        return PropertyBuffer<T>(id, typed);
+    }
+    return std::nullopt;
+}
+
+template <class T>
+std::optional<ConstPropertyBuffer<T>> PropertyRegistry::get(PropertyId id) const
+{
+    if (auto* typed = storage<T>(id))
+    {
+        return ConstPropertyBuffer<T>(id, typed);
+    }
+    return std::nullopt;
+}
+
+template <class T>
+PropertyBuffer<T> PropertyRegistry::get_or_add(std::string name, T default_value)
+{
+    if (auto existing = get<T>(name))
+    {
+        return *existing;
+    }
+
+    auto created = add<T>(std::move(name), std::move(default_value));
+    if (created)
+    {
+        return std::move(*created);
+    }
+    return PropertyBuffer<T>();
+}
+
+template <class T>
+bool PropertyRegistry::remove(PropertyBuffer<T>& handle)
+{
+    if (!handle)
+    {
+        return false;
+    }
+
+    auto* typed = storage<T>(handle.id_);
+    if (typed != handle.storage_)
+    {
+        return false;
+    }
+
+    const bool removed = remove(handle.id_);
+    if (removed)
+    {
+        handle.reset();
+    }
+    return removed;
+}
+
+} // namespace engine::geometry
+

--- a/engine/geometry/src/property_registry.cpp
+++ b/engine/geometry/src/property_registry.cpp
@@ -1,0 +1,147 @@
+#include "engine/geometry/property_registry.hpp"
+
+#include <algorithm>
+#include <cassert>
+
+namespace engine::geometry {
+
+PropertyRegistry::PropertyRegistry(const PropertyRegistry& other)
+    : storages_(), size_(other.size_)
+{
+    storages_.reserve(other.storages_.size());
+    for (const auto& storage : other.storages_)
+    {
+        storages_.push_back(storage->clone());
+    }
+}
+
+PropertyRegistry& PropertyRegistry::operator=(const PropertyRegistry& other)
+{
+    if (this == &other)
+    {
+        return *this;
+    }
+
+    storages_.clear();
+    storages_.reserve(other.storages_.size());
+    for (const auto& storage : other.storages_)
+    {
+        storages_.push_back(storage->clone());
+    }
+    size_ = other.size_;
+    return *this;
+}
+
+std::vector<std::string> PropertyRegistry::property_names() const
+{
+    std::vector<std::string> names;
+    names.reserve(storages_.size());
+    for (const auto& storage : storages_)
+    {
+        names.emplace_back(storage->name());
+    }
+    return names;
+}
+
+void PropertyRegistry::clear()
+{
+    storages_.clear();
+    size_ = 0;
+}
+
+void PropertyRegistry::reserve(std::size_t n)
+{
+    for (auto& storage : storages_)
+    {
+        storage->reserve(n);
+    }
+}
+
+void PropertyRegistry::resize(std::size_t n)
+{
+    for (auto& storage : storages_)
+    {
+        storage->resize(n);
+    }
+    size_ = n;
+}
+
+void PropertyRegistry::shrink_to_fit()
+{
+    for (auto& storage : storages_)
+    {
+        storage->shrink_to_fit();
+    }
+}
+
+void PropertyRegistry::push_back()
+{
+    for (auto& storage : storages_)
+    {
+        storage->push_back();
+    }
+    ++size_;
+}
+
+void PropertyRegistry::swap(std::size_t i0, std::size_t i1)
+{
+    assert(i0 < size_ && i1 < size_);
+    if (i0 == i1)
+    {
+        return;
+    }
+
+    for (auto& storage : storages_)
+    {
+        storage->swap(i0, i1);
+    }
+}
+
+bool PropertyRegistry::contains(std::string_view name) const
+{
+    return find(name).has_value();
+}
+
+std::optional<PropertyId> PropertyRegistry::find(std::string_view name) const
+{
+    for (PropertyId id = 0; id < storages_.size(); ++id)
+    {
+        if (storages_[id]->name() == name)
+        {
+            return id;
+        }
+    }
+    return std::nullopt;
+}
+
+bool PropertyRegistry::remove(PropertyId id)
+{
+    if (id >= storages_.size())
+    {
+        return false;
+    }
+
+    storages_.erase(storages_.begin() + static_cast<std::ptrdiff_t>(id));
+    return true;
+}
+
+detail::PropertyStorageBase* PropertyRegistry::storage(PropertyId id) noexcept
+{
+    if (id >= storages_.size())
+    {
+        return nullptr;
+    }
+    return storages_[id].get();
+}
+
+const detail::PropertyStorageBase* PropertyRegistry::storage(PropertyId id) const noexcept
+{
+    if (id >= storages_.size())
+    {
+        return nullptr;
+    }
+    return storages_[id].get();
+}
+
+} // namespace engine::geometry
+

--- a/engine/geometry/tests/CMakeLists.txt
+++ b/engine/geometry/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(engine_geometry_tests
     test_module.cpp
+    test_property_registry.cpp
     test_shapes.cpp
 )
 

--- a/engine/geometry/tests/README.md
+++ b/engine/geometry/tests/README.md
@@ -1,4 +1,5 @@
 # engine/geometry/tests
 
 This directory collects the C++ engine source tree, the geometry subsystem for meshes, primitives, and spatial algorithms, automated tests validating this layer.
+It now includes coverage for the property registry to guarantee optional-based lookup semantics, default value propagation, and removal bookkeeping.
 Future additions should place additional contributions to automated tests validating this layer here to keep related work easy to discover.

--- a/engine/geometry/tests/test_property_registry.cpp
+++ b/engine/geometry/tests/test_property_registry.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "engine/geometry/property_registry.hpp"
+
+namespace geo = engine::geometry;
+
+TEST(PropertyRegistry, AddGetAndDefaults)
+{
+    geo::PropertyRegistry registry;
+    auto weights_opt = registry.add<float>("weight", 1.5f);
+    ASSERT_EQ(weights_opt.has_value(), true);
+    auto weights = *weights_opt;
+    EXPECT_EQ(registry.size(), 0u);
+    EXPECT_EQ(registry.property_count(), 1u);
+
+    registry.resize(3);
+    ASSERT_EQ(weights.vector().size(), 3u);
+    EXPECT_FLOAT_EQ(weights[0], 1.5f);
+    EXPECT_FLOAT_EQ(weights[2], 1.5f);
+
+    weights.vector()[1] = 2.0f;
+    registry.push_back();
+    EXPECT_EQ(registry.size(), 4u);
+    EXPECT_FLOAT_EQ(weights[1], 2.0f);
+    EXPECT_FLOAT_EQ(weights[3], 1.5f);
+
+    const auto duplicate = registry.add<float>("weight", 9.0f);
+    EXPECT_TRUE(!duplicate.has_value());
+
+    auto labels_opt = registry.add<std::string>("label", std::string{"unset"});
+    ASSERT_EQ(labels_opt.has_value(), true);
+    auto labels = *labels_opt;
+    EXPECT_EQ(labels.vector().size(), registry.size());
+    EXPECT_EQ(labels[3], "unset");
+
+    labels.vector()[0] = "first";
+    labels.vector()[1] = "second";
+    registry.swap(0, 1);
+    EXPECT_EQ(labels[0], "second");
+    EXPECT_EQ(labels[1], "first");
+
+    const geo::PropertyRegistry& const_registry = registry;
+    auto const_labels = const_registry.get<std::string>("label");
+    ASSERT_EQ(const_labels.has_value(), true);
+    EXPECT_EQ((*const_labels)[0], "second");
+
+    auto maybe_missing = const_registry.get<float>("missing");
+    EXPECT_TRUE(!maybe_missing.has_value());
+
+    auto weights_again = registry.get_or_add<float>("weight", 3.0f);
+    EXPECT_TRUE(static_cast<bool>(weights_again));
+    EXPECT_EQ(weights_again.id(), weights.id());
+    EXPECT_FLOAT_EQ(weights_again[0], 2.0f);
+    EXPECT_FLOAT_EQ(weights_again[1], 1.5f);
+
+    auto ids = registry.get_or_add<int>("id", 7);
+    EXPECT_EQ(ids.vector().size(), registry.size());
+    EXPECT_TRUE(std::all_of(ids.vector().begin(), ids.vector().end(), [](int v) { return v == 7; }));
+
+    EXPECT_TRUE(registry.contains("id"));
+    auto id_lookup = registry.find("id");
+    ASSERT_EQ(id_lookup.has_value(), true);
+    EXPECT_TRUE(registry.remove(*id_lookup));
+    EXPECT_TRUE(!registry.contains("id"));
+
+    EXPECT_TRUE(registry.remove(weights_again));
+    EXPECT_TRUE(!static_cast<bool>(weights_again));
+    EXPECT_TRUE(!registry.contains("weight"));
+    EXPECT_TRUE(!registry.get<float>("weight"));
+
+    registry.clear();
+    EXPECT_EQ(registry.size(), 0u);
+    EXPECT_EQ(registry.property_count(), 0u);
+}
+


### PR DESCRIPTION
## Summary
- add a type-erased `PropertyRegistry` with optional lookups and typed buffer views for mesh attributes
- expose the registry through the geometry module and document the new facility in the relevant READMEs
- extend the geometry test suite to cover property creation, retrieval, swapping, and removal semantics

## Testing
- ctest --test-dir build --output-on-failure -R engine_geometry_tests

------
https://chatgpt.com/codex/tasks/task_e_68d8627de8fc8320be4c52a06348fc59