### PR TITLE
Add graph and point cloud primitives with tests

### DIFF
--- a/engine/geometry/CMakeLists.txt
+++ b/engine/geometry/CMakeLists.txt
@@ -2,8 +2,10 @@ set(target_name engine_geometry)
 
 add_library(${target_name}
     src/api.cpp
+    src/graph/graph.cpp
     src/property_registry.cpp
     src/mesh/halfedge_mesh.cpp
+    src/point_cloud.cpp
     src/shapes/aabb.cpp
     src/shapes/cylinder.cpp
     src/shapes/ellipsoid.cpp

--- a/engine/geometry/include/engine/geometry/README.md
+++ b/engine/geometry/include/engine/geometry/README.md
@@ -1,5 +1,6 @@
 # engine/geometry/include/engine/geometry
 
 This directory collects the C++ engine source tree, the geometry subsystem for meshes, primitives, and spatial algorithms, public headers defining the subsystem API.
-The newly added `property_registry.hpp` header contains the type-erased registry that manages mesh and point-set attributes with optional-based discovery instead of throwing exceptions.
+The type-erased attribute system lives in `property_registry.hpp` and `property_set.hpp`, enabling structured property access shared by mesh, graph, and point-set data structures.
+General-purpose combinatorial graphs are available through `graph/graph.hpp`, and unstructured point sets are modelled by `point_cloud.hpp`, both exposing property accessors consistent with `mesh/halfedge_mesh.hpp`.
 Future additions should place additional contributions to public headers defining the subsystem API here to keep related work easy to discover.

--- a/engine/geometry/include/engine/geometry/graph/graph.hpp
+++ b/engine/geometry/include/engine/geometry/graph/graph.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "engine/geometry/property_set.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <compare>
+#include <limits>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::geometry::graph {
+
+class Graph;
+
+using GraphIndex = std::uint32_t;
+
+constexpr GraphIndex kInvalidGraphIndex = std::numeric_limits<GraphIndex>::max();
+
+class GraphHandle {
+public:
+    using index_type = GraphIndex;
+
+    constexpr GraphHandle() noexcept = default;
+    explicit constexpr GraphHandle(index_type idx) noexcept : index_(idx) {}
+
+    [[nodiscard]] constexpr index_type index() const noexcept { return index_; }
+    [[nodiscard]] constexpr bool is_valid() const noexcept { return index_ != kInvalidGraphIndex; }
+    constexpr void reset() noexcept { index_ = kInvalidGraphIndex; }
+
+    [[nodiscard]] auto operator<=>(const GraphHandle&) const noexcept = default;
+
+protected:
+    index_type index_{kInvalidGraphIndex};
+};
+
+class VertexHandle final : public GraphHandle {
+public:
+    using GraphHandle::GraphHandle;
+};
+
+class EdgeHandle final : public GraphHandle {
+public:
+    using GraphHandle::GraphHandle;
+};
+
+std::ostream& operator<<(std::ostream& os, VertexHandle v);
+std::ostream& operator<<(std::ostream& os, EdgeHandle e);
+
+class Graph {
+public:
+    Graph();
+    Graph(const Graph& rhs);
+    Graph(Graph&&) noexcept = default;
+    Graph& operator=(const Graph& rhs);
+    Graph& operator=(Graph&&) noexcept = default;
+    ~Graph();
+
+    void clear();
+
+    void reserve_vertices(std::size_t count);
+    void reserve_edges(std::size_t count);
+
+    [[nodiscard]] std::size_t vertex_count() const noexcept { return adjacency_.size(); }
+    [[nodiscard]] std::size_t edge_count() const noexcept { return edges_.size(); }
+
+    [[nodiscard]] bool is_empty() const noexcept { return vertex_count() == 0; }
+
+    [[nodiscard]] bool is_valid(VertexHandle v) const noexcept;
+    [[nodiscard]] bool is_valid(EdgeHandle e) const noexcept;
+
+    VertexHandle add_vertex();
+    std::optional<EdgeHandle> add_edge(VertexHandle v0, VertexHandle v1);
+
+    [[nodiscard]] const std::vector<EdgeHandle>& incident_edges(VertexHandle v) const;
+    [[nodiscard]] std::vector<VertexHandle> neighbors(VertexHandle v) const;
+    [[nodiscard]] std::size_t degree(VertexHandle v) const;
+
+    [[nodiscard]] std::pair<VertexHandle, VertexHandle> endpoints(EdgeHandle e) const;
+    [[nodiscard]] VertexHandle vertex(EdgeHandle e, unsigned int i) const;
+
+    template <class T>
+    [[nodiscard]] HandleProperty<VertexHandle, T> add_vertex_property(const std::string& name, T default_value = T())
+    {
+        return HandleProperty<VertexHandle, T>(vertex_props_.add<T>(name, default_value));
+    }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<VertexHandle, T> get_vertex_property(const std::string& name) const
+    {
+        return HandleProperty<VertexHandle, T>(vertex_props_.get<T>(name));
+    }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<VertexHandle, T> vertex_property(const std::string& name, T default_value = T())
+    {
+        return HandleProperty<VertexHandle, T>(vertex_props_.get_or_add<T>(name, default_value));
+    }
+
+    template <class T>
+    void remove_vertex_property(HandleProperty<VertexHandle, T>& prop)
+    {
+        vertex_props_.remove(prop);
+    }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<EdgeHandle, T> add_edge_property(const std::string& name, T default_value = T())
+    {
+        return HandleProperty<EdgeHandle, T>(edge_props_.add<T>(name, default_value));
+    }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<EdgeHandle, T> get_edge_property(const std::string& name) const
+    {
+        return HandleProperty<EdgeHandle, T>(edge_props_.get<T>(name));
+    }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<EdgeHandle, T> edge_property(const std::string& name, T default_value = T())
+    {
+        return HandleProperty<EdgeHandle, T>(edge_props_.get_or_add<T>(name, default_value));
+    }
+
+    template <class T>
+    void remove_edge_property(HandleProperty<EdgeHandle, T>& prop)
+    {
+        edge_props_.remove(prop);
+    }
+
+private:
+    struct EdgeRecord {
+        VertexHandle v0{};
+        VertexHandle v1{};
+    };
+
+    MeshPropertySet vertex_props_;
+    MeshPropertySet edge_props_;
+
+    std::vector<EdgeRecord> edges_;
+    std::vector<std::vector<EdgeHandle>> adjacency_;
+};
+
+inline bool Graph::is_valid(VertexHandle v) const noexcept
+{
+    return v.is_valid() && v.index() < adjacency_.size();
+}
+
+inline bool Graph::is_valid(EdgeHandle e) const noexcept
+{
+    return e.is_valid() && e.index() < edges_.size();
+}
+
+inline std::size_t Graph::degree(VertexHandle v) const
+{
+    return incident_edges(v).size();
+}
+
+inline VertexHandle Graph::vertex(EdgeHandle e, unsigned int i) const
+{
+    const auto [v0, v1] = endpoints(e);
+    return (i == 0U) ? v0 : v1;
+}
+
+} // namespace engine::geometry::graph
+
+namespace engine::geometry {
+using Graph = graph::Graph;
+}
+

--- a/engine/geometry/include/engine/geometry/mesh/halfedge_mesh.hpp
+++ b/engine/geometry/include/engine/geometry/mesh/halfedge_mesh.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "engine/geometry/property_registry.hpp"
+#include "engine/geometry/property_set.hpp"
 #include "engine/math/vector.hpp"
 
 #include <array>
@@ -68,80 +69,6 @@ std::ostream& operator<<(std::ostream& os, VertexHandle v);
 std::ostream& operator<<(std::ostream& os, HalfedgeHandle h);
 std::ostream& operator<<(std::ostream& os, EdgeHandle e);
 std::ostream& operator<<(std::ostream& os, FaceHandle f);
-
-// Property wrappers -------------------------------------------------------------------------------------------------
-
-template <class T>
-class Property {
-public:
-    Property() = default;
-    explicit Property(PropertyBuffer<T> buffer) : buffer_(buffer) {}
-
-    [[nodiscard]] bool is_valid() const noexcept { return static_cast<bool>(buffer_); }
-
-    [[nodiscard]] decltype(auto) operator[](std::size_t index) const { return buffer_[index]; }
-    [[nodiscard]] decltype(auto) operator[](std::size_t index) { return buffer_[index]; }
-
-    [[nodiscard]] std::vector<T>& vector() { return buffer_.vector(); }
-    [[nodiscard]] const std::vector<T>& vector() const { return buffer_.vector(); }
-
-    [[nodiscard]] std::vector<T>& array() { return buffer_.vector(); }
-    [[nodiscard]] const std::vector<T>& array() const { return buffer_.vector(); }
-
-    [[nodiscard]] PropertyBuffer<T>& handle() noexcept { return buffer_; }
-    [[nodiscard]] const PropertyBuffer<T>& handle() const noexcept { return buffer_; }
-
-    void reset() noexcept { buffer_.reset(); }
-
-private:
-    PropertyBuffer<T> buffer_;
-};
-
-template <class HandleT, class T>
-class HandleProperty : public Property<T> {
-public:
-    using Property<T>::Property;
-
-    explicit HandleProperty(Property<T> base) : Property<T>(std::move(base)) {}
-
-    [[nodiscard]] decltype(auto) operator[](HandleT handle) { return Property<T>::operator[](handle.index()); }
-    [[nodiscard]] decltype(auto) operator[](HandleT handle) const { return Property<T>::operator[](handle.index()); }
-};
-
-class MeshPropertySet {
-public:
-    MeshPropertySet() = default;
-
-    [[nodiscard]] std::size_t size() const noexcept { return registry_.size(); }
-
-    void clear();
-    void reserve(std::size_t n);
-    void resize(std::size_t n);
-    void push_back();
-    void swap(std::size_t i0, std::size_t i1);
-    void shrink_to_fit();
-
-    [[nodiscard]] bool exists(std::string_view name) const;
-    [[nodiscard]] std::vector<std::string> properties() const;
-
-    template <class T>
-    [[nodiscard]] Property<T> add(std::string name, T default_value = T());
-
-    template <class T>
-    [[nodiscard]] Property<T> get(std::string_view name);
-
-    template <class T>
-    [[nodiscard]] Property<T> get_or_add(std::string name, T default_value = T());
-
-    template <class T>
-    void remove(Property<T>& property);
-
-    PropertyRegistry& registry() noexcept { return registry_; }
-    const PropertyRegistry& registry() const noexcept { return registry_; }
-
-private:
-    PropertyRegistry registry_;
-};
 
 template <class T>
 using VertexProperty = HandleProperty<VertexHandle, T>;
@@ -802,80 +729,6 @@ private:
 };
 
 // Inline implementations --------------------------------------------------------------------------------------------
-
-inline void MeshPropertySet::clear()
-{
-    registry_.clear();
-}
-
-inline void MeshPropertySet::reserve(std::size_t n)
-{
-    registry_.reserve(n);
-}
-
-inline void MeshPropertySet::resize(std::size_t n)
-{
-    registry_.resize(n);
-}
-
-inline void MeshPropertySet::push_back()
-{
-    registry_.push_back();
-}
-
-inline void MeshPropertySet::swap(std::size_t i0, std::size_t i1)
-{
-    registry_.swap(i0, i1);
-}
-
-inline void MeshPropertySet::shrink_to_fit()
-{
-    registry_.shrink_to_fit();
-}
-
-inline bool MeshPropertySet::exists(std::string_view name) const
-{
-    return registry_.contains(name);
-}
-
-inline std::vector<std::string> MeshPropertySet::properties() const
-{
-    return registry_.property_names();
-}
-
-template <class T>
-inline Property<T> MeshPropertySet::add(std::string name, T default_value)
-{
-    if (auto handle = registry_.add<T>(std::move(name), std::move(default_value)))
-    {
-        return Property<T>(*handle);
-    }
-    return Property<T>();
-}
-
-template <class T>
-inline Property<T> MeshPropertySet::get(std::string_view name)
-{
-    if (auto handle = registry_.get<T>(name))
-    {
-        return Property<T>(*handle);
-    }
-    return Property<T>();
-}
-
-template <class T>
-inline Property<T> MeshPropertySet::get_or_add(std::string name, T default_value)
-{
-    auto handle = registry_.get_or_add<T>(std::move(name), std::move(default_value));
-    return Property<T>(handle);
-}
-
-template <class T>
-inline void MeshPropertySet::remove(Property<T>& property)
-{
-    registry_.remove(property.handle());
-    property.reset();
-}
 
 } // namespace engine::geometry
 

--- a/engine/geometry/include/engine/geometry/point_cloud.hpp
+++ b/engine/geometry/include/engine/geometry/point_cloud.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "engine/geometry/property_set.hpp"
+#include "engine/math/vector.hpp"
+
+#include <compare>
+#include <cstdint>
+#include <limits>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::geometry {
+
+using PointIndex = std::uint32_t;
+
+constexpr PointIndex kInvalidPointIndex = std::numeric_limits<PointIndex>::max();
+
+class PointHandle {
+public:
+    using index_type = PointIndex;
+
+    constexpr PointHandle() noexcept = default;
+    explicit constexpr PointHandle(index_type idx) noexcept : index_(idx) {}
+
+    [[nodiscard]] constexpr index_type index() const noexcept { return index_; }
+    [[nodiscard]] constexpr bool is_valid() const noexcept { return index_ != kInvalidPointIndex; }
+    constexpr void reset() noexcept { index_ = kInvalidPointIndex; }
+
+    [[nodiscard]] auto operator<=>(const PointHandle&) const noexcept = default;
+
+private:
+    index_type index_{kInvalidPointIndex};
+};
+
+std::ostream& operator<<(std::ostream& os, PointHandle p);
+
+class PointCloud {
+public:
+    using Point = math::vec3;
+
+    PointCloud();
+    PointCloud(const PointCloud& rhs);
+    PointCloud(PointCloud&&) noexcept = default;
+    PointCloud& operator=(const PointCloud& rhs);
+    PointCloud& operator=(PointCloud&&) noexcept = default;
+    ~PointCloud();
+
+    void clear();
+
+    void reserve(std::size_t count);
+
+    [[nodiscard]] std::size_t point_count() const noexcept { return point_props_.size(); }
+    [[nodiscard]] bool is_empty() const noexcept { return point_count() == 0; }
+
+    [[nodiscard]] bool is_valid(PointHandle handle) const noexcept
+    {
+        return handle.is_valid() && handle.index() < point_count();
+    }
+
+    PointHandle add_point(const Point& point);
+
+    [[nodiscard]] const Point& position(PointHandle handle) const { return point_positions_[handle]; }
+    [[nodiscard]] Point& position(PointHandle handle) { return point_positions_[handle]; }
+
+    [[nodiscard]] std::vector<Point>& positions() { return point_positions_.vector(); }
+    [[nodiscard]] const std::vector<Point>& positions() const { return point_positions_.vector(); }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<PointHandle, T> add_point_property(const std::string& name, T default_value = T())
+    {
+        return HandleProperty<PointHandle, T>(point_props_.add<T>(name, default_value));
+    }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<PointHandle, T> get_point_property(const std::string& name) const
+    {
+        return HandleProperty<PointHandle, T>(point_props_.get<T>(name));
+    }
+
+    template <class T>
+    [[nodiscard]] HandleProperty<PointHandle, T> point_property(const std::string& name, T default_value = T())
+    {
+        return HandleProperty<PointHandle, T>(point_props_.get_or_add<T>(name, default_value));
+    }
+
+    template <class T>
+    void remove_point_property(HandleProperty<PointHandle, T>& property)
+    {
+        point_props_.remove(property);
+    }
+
+private:
+    void ensure_position_property();
+
+    MeshPropertySet point_props_;
+    HandleProperty<PointHandle, Point> point_positions_;
+};
+
+} // namespace engine::geometry
+

--- a/engine/geometry/include/engine/geometry/property_set.hpp
+++ b/engine/geometry/include/engine/geometry/property_set.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "engine/geometry/property_registry.hpp"
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace engine::geometry {
+
+template <class T>
+class Property {
+public:
+    Property() = default;
+    explicit Property(PropertyBuffer<T> buffer) : buffer_(buffer) {}
+
+    [[nodiscard]] bool is_valid() const noexcept { return static_cast<bool>(buffer_); }
+
+    [[nodiscard]] decltype(auto) operator[](std::size_t index) const { return buffer_[index]; }
+    [[nodiscard]] decltype(auto) operator[](std::size_t index) { return buffer_[index]; }
+
+    [[nodiscard]] std::vector<T>& vector() { return buffer_.vector(); }
+    [[nodiscard]] const std::vector<T>& vector() const { return buffer_.vector(); }
+
+    [[nodiscard]] std::vector<T>& array() { return buffer_.vector(); }
+    [[nodiscard]] const std::vector<T>& array() const { return buffer_.vector(); }
+
+    [[nodiscard]] PropertyBuffer<T>& handle() noexcept { return buffer_; }
+    [[nodiscard]] const PropertyBuffer<T>& handle() const noexcept { return buffer_; }
+
+    void reset() noexcept { buffer_.reset(); }
+
+private:
+    PropertyBuffer<T> buffer_;
+};
+
+template <class HandleT, class T>
+class HandleProperty : public Property<T> {
+public:
+    using Property<T>::Property;
+
+    explicit HandleProperty(Property<T> base) : Property<T>(std::move(base)) {}
+
+    [[nodiscard]] decltype(auto) operator[](HandleT handle) { return Property<T>::operator[](handle.index()); }
+    [[nodiscard]] decltype(auto) operator[](HandleT handle) const { return Property<T>::operator[](handle.index()); }
+};
+
+class MeshPropertySet {
+public:
+    MeshPropertySet() = default;
+
+    [[nodiscard]] std::size_t size() const noexcept { return registry_.size(); }
+
+    void clear();
+    void reserve(std::size_t n);
+    void resize(std::size_t n);
+    void push_back();
+    void swap(std::size_t i0, std::size_t i1);
+    void shrink_to_fit();
+
+    [[nodiscard]] bool exists(std::string_view name) const;
+    [[nodiscard]] std::vector<std::string> properties() const;
+
+    template <class T>
+    [[nodiscard]] Property<T> add(std::string name, T default_value = T());
+
+    template <class T>
+    [[nodiscard]] Property<T> get(std::string_view name);
+
+    template <class T>
+    [[nodiscard]] Property<T> get(std::string_view name) const;
+
+    template <class T>
+    [[nodiscard]] Property<T> get_or_add(std::string name, T default_value = T());
+
+    template <class T>
+    void remove(Property<T>& property);
+
+    PropertyRegistry& registry() noexcept { return registry_; }
+    const PropertyRegistry& registry() const noexcept { return registry_; }
+
+private:
+    PropertyRegistry registry_;
+};
+
+inline void MeshPropertySet::clear()
+{
+    registry_.clear();
+}
+
+inline void MeshPropertySet::reserve(std::size_t n)
+{
+    registry_.reserve(n);
+}
+
+inline void MeshPropertySet::resize(std::size_t n)
+{
+    registry_.resize(n);
+}
+
+inline void MeshPropertySet::push_back()
+{
+    registry_.push_back();
+}
+
+inline void MeshPropertySet::swap(std::size_t i0, std::size_t i1)
+{
+    registry_.swap(i0, i1);
+}
+
+inline void MeshPropertySet::shrink_to_fit()
+{
+    registry_.shrink_to_fit();
+}
+
+inline bool MeshPropertySet::exists(std::string_view name) const
+{
+    return registry_.contains(name);
+}
+
+inline std::vector<std::string> MeshPropertySet::properties() const
+{
+    return registry_.property_names();
+}
+
+template <class T>
+inline Property<T> MeshPropertySet::add(std::string name, T default_value)
+{
+    if (auto handle = registry_.add<T>(std::move(name), std::move(default_value)))
+    {
+        return Property<T>(*handle);
+    }
+    return Property<T>();
+}
+
+template <class T>
+inline Property<T> MeshPropertySet::get(std::string_view name)
+{
+    if (auto handle = registry_.get<T>(name))
+    {
+        return Property<T>(*handle);
+    }
+    return Property<T>();
+}
+
+template <class T>
+inline Property<T> MeshPropertySet::get(std::string_view name) const
+{
+    return const_cast<MeshPropertySet*>(this)->get<T>(name);
+}
+
+template <class T>
+inline Property<T> MeshPropertySet::get_or_add(std::string name, T default_value)
+{
+    auto handle = registry_.get_or_add<T>(std::move(name), std::move(default_value));
+    return Property<T>(handle);
+}
+
+template <class T>
+inline void MeshPropertySet::remove(Property<T>& property)
+{
+    registry_.remove(property.handle());
+    property.reset();
+}
+
+} // namespace engine::geometry
+

--- a/engine/geometry/src/graph/graph.cpp
+++ b/engine/geometry/src/graph/graph.cpp
@@ -1,0 +1,97 @@
+#include "engine/geometry/graph/graph.hpp"
+
+namespace engine::geometry::graph {
+
+std::ostream& operator<<(std::ostream& os, VertexHandle v)
+{
+    return os << 'v' << v.index();
+}
+
+std::ostream& operator<<(std::ostream& os, EdgeHandle e)
+{
+    return os << 'e' << e.index();
+}
+
+Graph::Graph() = default;
+
+Graph::Graph(const Graph& rhs) = default;
+
+Graph& Graph::operator=(const Graph& rhs) = default;
+
+Graph::~Graph() = default;
+
+void Graph::clear()
+{
+    edges_.clear();
+    adjacency_.clear();
+    vertex_props_.clear();
+    edge_props_.clear();
+}
+
+void Graph::reserve_vertices(std::size_t count)
+{
+    adjacency_.reserve(count);
+    vertex_props_.reserve(count);
+}
+
+void Graph::reserve_edges(std::size_t count)
+{
+    edges_.reserve(count);
+    edge_props_.reserve(count);
+}
+
+VertexHandle Graph::add_vertex()
+{
+    const auto index = static_cast<VertexHandle::index_type>(adjacency_.size());
+    adjacency_.emplace_back();
+    vertex_props_.push_back();
+    return VertexHandle(index);
+}
+
+std::optional<EdgeHandle> Graph::add_edge(VertexHandle v0, VertexHandle v1)
+{
+    if (!is_valid(v0) || !is_valid(v1))
+    {
+        return std::nullopt;
+    }
+
+    const auto index = static_cast<EdgeHandle::index_type>(edges_.size());
+    edges_.push_back({v0, v1});
+    edge_props_.push_back();
+
+    const EdgeHandle handle{index};
+    adjacency_[v0.index()].push_back(handle);
+    adjacency_[v1.index()].push_back(handle);
+
+    return handle;
+}
+
+const std::vector<EdgeHandle>& Graph::incident_edges(VertexHandle v) const
+{
+    assert(is_valid(v));
+    return adjacency_[v.index()];
+}
+
+std::vector<VertexHandle> Graph::neighbors(VertexHandle v) const
+{
+    assert(is_valid(v));
+    const auto& edges = adjacency_[v.index()];
+    std::vector<VertexHandle> result;
+    result.reserve(edges.size());
+    for (auto edge : edges)
+    {
+        const auto [a, b] = endpoints(edge);
+        result.push_back((a == v) ? b : a);
+    }
+    return result;
+}
+
+std::pair<VertexHandle, VertexHandle> Graph::endpoints(EdgeHandle e) const
+{
+    assert(is_valid(e));
+    const auto& record = edges_[e.index()];
+    return {record.v0, record.v1};
+}
+
+} // namespace engine::geometry::graph
+

--- a/engine/geometry/src/point_cloud.cpp
+++ b/engine/geometry/src/point_cloud.cpp
@@ -1,0 +1,81 @@
+#include "engine/geometry/point_cloud.hpp"
+
+#include <string>
+#include <string_view>
+
+namespace engine::geometry {
+
+namespace {
+constexpr std::string_view kPositionPropertyName{"p:position"};
+constexpr math::vec3 kZeroPoint{0.0F, 0.0F, 0.0F};
+}
+
+std::ostream& operator<<(std::ostream& os, PointHandle p)
+{
+    return os << 'p' << p.index();
+}
+
+PointCloud::PointCloud()
+{
+    ensure_position_property();
+}
+
+PointCloud::PointCloud(const PointCloud& rhs)
+    : point_props_(rhs.point_props_)
+{
+    ensure_position_property();
+}
+
+PointCloud& PointCloud::operator=(const PointCloud& rhs)
+{
+    if (this != &rhs)
+    {
+        point_props_ = rhs.point_props_;
+        point_positions_.reset();
+        ensure_position_property();
+    }
+    return *this;
+}
+
+PointCloud::~PointCloud() = default;
+
+void PointCloud::clear()
+{
+    point_props_.clear();
+    point_positions_.reset();
+    ensure_position_property();
+}
+
+void PointCloud::reserve(std::size_t count)
+{
+    ensure_position_property();
+    point_props_.reserve(count);
+}
+
+PointHandle PointCloud::add_point(const Point& point)
+{
+    ensure_position_property();
+    const auto index = static_cast<PointHandle::index_type>(point_count());
+    point_props_.push_back();
+    const PointHandle handle{index};
+    point_positions_[handle] = point;
+    return handle;
+}
+
+void PointCloud::ensure_position_property()
+{
+    if (point_positions_.is_valid())
+    {
+        return;
+    }
+
+    auto property = point_props_.get<Point>(kPositionPropertyName);
+    if (!property.is_valid())
+    {
+        property = point_props_.add<Point>(std::string(kPositionPropertyName), kZeroPoint);
+    }
+    point_positions_ = HandleProperty<PointHandle, Point>(property);
+}
+
+} // namespace engine::geometry
+

--- a/engine/geometry/tests/CMakeLists.txt
+++ b/engine/geometry/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ add_executable(engine_geometry_tests
     test_module.cpp
     test_property_registry.cpp
     test_halfedge_mesh.cpp
+    test_graph.cpp
+    test_point_cloud.cpp
     test_shapes.cpp
 )
 

--- a/engine/geometry/tests/test_graph.cpp
+++ b/engine/geometry/tests/test_graph.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+
+#include "engine/geometry/graph/graph.hpp"
+
+namespace geo = engine::geometry;
+namespace graph_ns = engine::geometry::graph;
+
+TEST(Graph, BuildsUndirectedConnectivity)
+{
+    geo::Graph graph;
+
+    const auto v0 = graph.add_vertex();
+    const auto v1 = graph.add_vertex();
+    const auto v2 = graph.add_vertex();
+
+    const auto e01 = graph.add_edge(v0, v1);
+    EXPECT_TRUE(e01.has_value());
+    if (!e01.has_value())
+    {
+        return;
+    }
+
+    const auto e12 = graph.add_edge(v1, v2);
+    EXPECT_TRUE(e12.has_value());
+    if (!e12.has_value())
+    {
+        return;
+    }
+
+    const auto e20 = graph.add_edge(v2, v0);
+    EXPECT_TRUE(e20.has_value());
+    if (!e20.has_value())
+    {
+        return;
+    }
+
+    EXPECT_EQ(graph.vertex_count(), 3U);
+    EXPECT_EQ(graph.edge_count(), 3U);
+
+    EXPECT_TRUE(graph.is_valid(v0));
+    EXPECT_TRUE(graph.is_valid(*e01));
+
+    EXPECT_EQ(graph.degree(v0), 2U);
+    EXPECT_EQ(graph.degree(v1), 2U);
+    EXPECT_EQ(graph.degree(v2), 2U);
+
+    const auto& incident = graph.incident_edges(v0);
+    ASSERT_EQ(incident.size(), 2U);
+    EXPECT_TRUE((incident[0] == *e01) || (incident[0] == *e20));
+
+    const auto neighbors = graph.neighbors(v0);
+    ASSERT_EQ(neighbors.size(), 2U);
+    EXPECT_TRUE((neighbors[0] == v1 && neighbors[1] == v2) || (neighbors[0] == v2 && neighbors[1] == v1));
+
+    const auto endpoints = graph.endpoints(*e01);
+    EXPECT_TRUE((endpoints.first == v0 && endpoints.second == v1) || (endpoints.first == v1 && endpoints.second == v0));
+
+    auto edge_property = graph.add_edge_property<float>("e:length", 1.0F);
+    EXPECT_FLOAT_EQ(edge_property[*e01], 1.0F);
+    edge_property[*e01] = 2.5F;
+
+    auto vertex_property = graph.add_vertex_property<int>("v:valence", 0);
+    vertex_property[v0] = static_cast<int>(graph.degree(v0));
+
+    const auto vertex_property_copy = graph.get_vertex_property<int>("v:valence");
+    EXPECT_EQ(vertex_property_copy[v0], 2);
+
+    const auto invalid_edge = graph.add_edge(graph_ns::VertexHandle(42U), v1);
+    EXPECT_TRUE(!invalid_edge.has_value());
+}
+
+TEST(Graph, CopiesAndClears)
+{
+    geo::Graph graph;
+    const auto v0 = graph.add_vertex();
+    const auto v1 = graph.add_vertex();
+
+    const auto e = graph.add_edge(v0, v1);
+    EXPECT_TRUE(e.has_value());
+    if (!e.has_value())
+    {
+        return;
+    }
+
+    auto weights = graph.add_vertex_property<float>("v:weight", 1.0F);
+    weights[v0] = 3.5F;
+
+    geo::Graph copy = graph;
+    const auto weights_copy = copy.get_vertex_property<float>("v:weight");
+    EXPECT_FLOAT_EQ(weights_copy[v0], 3.5F);
+    EXPECT_EQ(copy.edge_count(), graph.edge_count());
+
+    graph.clear();
+    EXPECT_TRUE(graph.is_empty());
+    EXPECT_EQ(graph.edge_count(), 0U);
+    EXPECT_EQ(graph.vertex_count(), 0U);
+
+    const auto new_v = graph.add_vertex();
+    EXPECT_TRUE(new_v.is_valid());
+    auto new_weights = graph.vertex_property<float>("v:weight", 0.0F);
+    EXPECT_FLOAT_EQ(new_weights[new_v], 0.0F);
+}
+

--- a/engine/geometry/tests/test_point_cloud.cpp
+++ b/engine/geometry/tests/test_point_cloud.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include "engine/geometry/point_cloud.hpp"
+
+namespace geo = engine::geometry;
+
+TEST(PointCloud, StoresPointsAndProperties)
+{
+    geo::PointCloud cloud;
+
+    const auto p0 = cloud.add_point({0.0F, 0.0F, 0.0F});
+    const auto p1 = cloud.add_point({1.0F, 2.0F, 3.0F});
+
+    EXPECT_EQ(cloud.point_count(), 2U);
+    EXPECT_TRUE(cloud.is_valid(p0));
+    EXPECT_FLOAT_EQ(cloud.position(p1)[2], 3.0F);
+
+    auto intensity = cloud.add_point_property<float>("p:intensity", 0.0F);
+    intensity[p1] = 5.0F;
+
+    const auto intensity_view = cloud.get_point_property<float>("p:intensity");
+    EXPECT_FLOAT_EQ(intensity_view[p1], 5.0F);
+
+    geo::PointCloud copy = cloud;
+    EXPECT_EQ(copy.point_count(), 2U);
+    EXPECT_FLOAT_EQ(copy.position(p1)[0], 1.0F);
+    const auto copy_intensity = copy.get_point_property<float>("p:intensity");
+    EXPECT_FLOAT_EQ(copy_intensity[p1], 5.0F);
+
+    cloud.clear();
+    EXPECT_TRUE(cloud.is_empty());
+
+    const auto p2 = cloud.add_point({4.0F, 5.0F, 6.0F});
+    EXPECT_EQ(cloud.point_count(), 1U);
+    EXPECT_FLOAT_EQ(cloud.position(p2)[1], 5.0F);
+
+    auto refreshed_intensity = cloud.point_property<float>("p:intensity", 0.0F);
+    EXPECT_FLOAT_EQ(refreshed_intensity[p2], 0.0F);
+}
+


### PR DESCRIPTION
## Summary
- introduce a reusable property_set wrapper for geometry element attributes and hook the halfedge mesh into it
- add a graph::Graph data structure with handles, adjacency queries, and property accessors plus unit coverage
- add a PointCloud container built on the shared property system and document/test the new geometry APIs

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d88de85d38832090ab05e1aba174b8