### PR TITLE
Implement comprehensive AABB shape interactions

### DIFF
--- a/engine/geometry/include/engine/geometry/shapes/ray.hpp
+++ b/engine/geometry/include/engine/geometry/shapes/ray.hpp
@@ -7,7 +7,7 @@ namespace engine::geometry {
 
 struct Aabb;
 struct Sphere;
-struct plane;
+struct Plane;
 
 struct ENGINE_GEOMETRY_API Ray {
     math::vec3 origin;
@@ -18,7 +18,7 @@ struct ENGINE_GEOMETRY_API Ray {
 
 [[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Ray& r, const Aabb& box, float& out_t_min, float& out_t_max) noexcept;
 [[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Ray& r, const Sphere& s, float& out_t) noexcept;
-[[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Ray& r, const plane& p, float& out_t) noexcept;
+[[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Ray& r, const Plane& p, float& out_t) noexcept;
 
 }  // namespace engine::geometry
 

--- a/engine/geometry/include/engine/geometry/shapes/sphere.hpp
+++ b/engine/geometry/include/engine/geometry/shapes/sphere.hpp
@@ -7,7 +7,7 @@ namespace engine::geometry {
 
 struct Aabb;
 struct Obb;
-struct cylinder;
+struct Cylinder;
 
 struct ENGINE_GEOMETRY_API Sphere {
     math::vec3 center;
@@ -24,7 +24,7 @@ struct ENGINE_GEOMETRY_API Sphere {
 [[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Sphere& lhs, const Sphere& rhs) noexcept;
 [[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Sphere& s, const Aabb& box) noexcept;
 [[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Sphere& s, const Obb& box) noexcept;
-[[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Sphere& s, const cylinder& c) noexcept;
+[[nodiscard]] ENGINE_GEOMETRY_API bool Intersects(const Sphere& s, const Cylinder& c) noexcept;
 
 [[nodiscard]] ENGINE_GEOMETRY_API Sphere make_sphere_from_point(const math::vec3& point) noexcept;
 [[nodiscard]] ENGINE_GEOMETRY_API Sphere bounding_sphere(const Aabb& box) noexcept;


### PR DESCRIPTION
## Summary
- implement the remaining AABB containment and intersection helpers for cylinders, ellipsoids, lines, planes, rays, segments, and triangles
- add bounding box construction for additional primitives and align shape headers with the established type naming
- extend the geometry shape tests to cover the new containment, intersection, and bounding behaviours

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dceb817f0483208d4ad46e4cceb6f3