### PR TITLE
Implement sphere interactions and add dedicated tests

### DIFF
--- a/engine/geometry/include/engine/geometry/octree/octree.hpp
+++ b/engine/geometry/include/engine/geometry/octree/octree.hpp
@@ -5,6 +5,7 @@
 #include "engine/geometry/properties/property_handle.hpp"
 #include "engine/geometry/shapes/aabb.hpp"
 #include "engine/geometry/shapes/sphere.hpp"
+#include "engine/geometry/utils/shape_interactions.hpp"
 
 #include "engine/geometry/utils/bounded_heap.hpp"
 #include "engine/math/vector.hpp"

--- a/engine/geometry/src/shapes/aabb.cpp
+++ b/engine/geometry/src/shapes/aabb.cpp
@@ -125,11 +125,12 @@ namespace engine::geometry {
     }
 
     Aabb BoundingAabb(const Ellipsoid &s) noexcept {
+        const math::mat3 R = s.orientation.to_rotation_matrix();
         math::vec3 extent{0.0f};
         for (std::size_t row = 0; row < 3; ++row) {
             float sum = 0.0f;
             for (std::size_t col = 0; col < 3; ++col) {
-                sum += std::fabs(s.orientation[row][col]) * s.radii[col];
+                sum += std::fabs(R[row][col]) * s.radii[col];
             }
             extent[row] = sum;
         }

--- a/engine/geometry/src/shapes/ellipsoid.cpp
+++ b/engine/geometry/src/shapes/ellipsoid.cpp
@@ -21,7 +21,7 @@ namespace engine::geometry {
         }
 
         const math::vec3 offset = point - ellipsoid.center;
-        const math::mat3 rotation = ellipsoid.orientation;
+        const math::mat3 rotation = ellipsoid.orientation.to_rotation_matrix();
         const math::mat3 rotation_transposed = math::transpose(rotation);
         const math::vec3 local = rotation_transposed * offset;
 

--- a/engine/geometry/tests/CMakeLists.txt
+++ b/engine/geometry/tests/CMakeLists.txt
@@ -7,6 +7,23 @@ add_executable(engine_geometry_tests
     test_shapes.cpp
 )
 
+add_executable(engine_geometry_shape_interactions_tests
+    test_shape_interactions.cpp
+)
+
+set_target_properties(engine_geometry_shape_interactions_tests PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_link_libraries(engine_geometry_shape_interactions_tests
+    PRIVATE
+        engine_geometry
+        GTest::gtest_main
+)
+
+add_test(NAME engine_geometry_shape_interactions_tests COMMAND engine_geometry_shape_interactions_tests)
+
 set_target_properties(engine_geometry_tests PROPERTIES
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES

--- a/engine/geometry/tests/test_shape_interactions.cpp
+++ b/engine/geometry/tests/test_shape_interactions.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include "engine/geometry/shapes.hpp"
+#include "engine/geometry/utils/shape_interactions.hpp"
+
+namespace engine::geometry
+{
+    TEST(ShapeInteractionsSphere, CylinderIntersection)
+    {
+        const Cylinder cylinder{{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, 1.0f, 1.5f};
+        const Sphere intersecting{{1.3f, 0.0f, 0.0f}, 0.6f};
+        const Sphere separated{{1.8f, 0.0f, 0.0f}, 0.6f};
+
+        EXPECT_TRUE(Intersects(cylinder, intersecting));
+        EXPECT_TRUE(!Intersects(cylinder, separated));
+    }
+
+    TEST(ShapeInteractionsSphere, EllipsoidIntersection)
+    {
+        const Ellipsoid ellipsoid{{0.0f, 0.0f, 0.0f}, {2.0f, 1.0f, 1.5f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+        const Sphere intersecting{{1.0f, 0.0f, 0.0f}, 0.75f};
+        const Sphere separated{{3.5f, 0.0f, 0.0f}, 0.25f};
+
+        EXPECT_TRUE(Intersects(ellipsoid, intersecting));
+        EXPECT_TRUE(!Intersects(ellipsoid, separated));
+    }
+
+    TEST(ShapeInteractionsSphere, ObbIntersection)
+    {
+        const Obb box{{0.0f, 0.0f, 0.0f}, {1.0f, 2.0f, 1.0f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+        const Sphere inside{{0.5f, 0.0f, 0.0f}, 0.5f};
+        const Sphere outside{{3.0f, 0.0f, 0.0f}, 0.25f};
+
+        EXPECT_TRUE(Intersects(box, inside));
+        EXPECT_TRUE(!Intersects(box, outside));
+    }
+
+    TEST(ShapeInteractionsSphere, SphereIntersection)
+    {
+        const Sphere a{{0.0f, 0.0f, 0.0f}, 1.5f};
+        const Sphere b{{2.0f, 0.0f, 0.0f}, 0.6f};
+        const Sphere c{{3.5f, 0.0f, 0.0f}, 0.5f};
+
+        EXPECT_TRUE(Intersects(a, b));
+        EXPECT_TRUE(!Intersects(a, c));
+    }
+
+    TEST(ShapeInteractionsSphere, SphereSegmentIntersection)
+    {
+        const Sphere sphere{{0.0f, 0.0f, 0.0f}, 1.0f};
+        const Segment hit{{-2.0f, 0.0f, 0.0f}, {2.0f, 0.0f, 0.0f}};
+        const Segment miss{{2.0f, 2.0f, 0.0f}, {4.0f, 2.0f, 0.0f}};
+
+        EXPECT_TRUE(Intersects(sphere, hit, nullptr));
+        EXPECT_TRUE(!Intersects(sphere, miss, nullptr));
+    }
+
+    TEST(ShapeInteractionsSphereContains, SphereInsideAabb)
+    {
+        const Aabb box{{-3.0f, -2.0f, -1.0f}, {3.0f, 2.0f, 1.0f}};
+        const Sphere contained{{0.0f, 0.0f, 0.0f}, 1.0f};
+        const Sphere spilling{{2.5f, 0.0f, 0.0f}, 1.0f};
+
+        EXPECT_TRUE(Contains(box, contained));
+        EXPECT_TRUE(!Contains(box, spilling));
+    }
+
+    TEST(ShapeInteractionsSphereContains, SphereInsideCylinder)
+    {
+        const Cylinder cylinder{{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 2.0f}, 2.0f, 2.0f};
+        const Sphere contained{{0.0f, 0.0f, 0.0f}, 1.0f};
+        const Sphere spilling{{1.5f, 0.0f, 1.75f}, 0.6f};
+
+        EXPECT_TRUE(Contains(cylinder, contained));
+        EXPECT_TRUE(!Contains(cylinder, spilling));
+    }
+
+    TEST(ShapeInteractionsSphereContains, SphereInsideEllipsoid)
+    {
+        const Ellipsoid ellipsoid{{1.0f, 0.0f, 0.0f}, {3.0f, 2.0f, 1.0f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+        const Sphere contained{{2.0f, 0.0f, 0.0f}, 0.5f};
+        const Sphere spilling{{3.5f, 0.0f, 0.0f}, 0.75f};
+
+        EXPECT_TRUE(Contains(ellipsoid, contained));
+        EXPECT_TRUE(!Contains(ellipsoid, spilling));
+    }
+
+    TEST(ShapeInteractionsSphereContains, SphereInsideObb)
+    {
+        const Obb box{{0.0f, 0.0f, 0.0f}, {2.0f, 1.5f, 1.0f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+        const Sphere contained{{0.5f, 0.0f, 0.0f}, 0.75f};
+        const Sphere spilling{{1.8f, 0.0f, 0.0f}, 0.5f};
+
+        EXPECT_TRUE(Contains(box, contained));
+        EXPECT_TRUE(!Contains(box, spilling));
+    }
+
+    TEST(ShapeInteractionsSphereContains, AabbInsideSphere)
+    {
+        const Sphere sphere{{0.0f, 0.0f, 0.0f}, 5.0f};
+        const Aabb inside{{-1.0f, -1.0f, -1.0f}, {1.0f, 1.0f, 1.0f}};
+        const Aabb outside{{-5.5f, 0.0f, 0.0f}, {5.5f, 1.0f, 1.0f}};
+
+        EXPECT_TRUE(Contains(sphere, inside));
+        EXPECT_TRUE(!Contains(sphere, outside));
+    }
+
+    TEST(ShapeInteractionsSphereContains, CylinderInsideSphere)
+    {
+        const Sphere sphere{{0.0f, 0.0f, 0.0f}, 4.0f};
+        const Cylinder inside{{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, 1.0f, 1.5f};
+        const Cylinder outside{{3.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, 1.0f, 1.0f};
+
+        EXPECT_TRUE(Contains(sphere, inside));
+        EXPECT_TRUE(!Contains(sphere, outside));
+    }
+
+    TEST(ShapeInteractionsSphereContains, EllipsoidInsideSphere)
+    {
+        const Sphere sphere{{0.0f, 0.0f, 0.0f}, 5.0f};
+        const Ellipsoid inside{{1.0f, 0.0f, 0.0f}, {1.0f, 1.5f, 2.0f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+        const Ellipsoid outside{{4.6f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+
+        EXPECT_TRUE(Contains(sphere, inside));
+        EXPECT_TRUE(!Contains(sphere, outside));
+    }
+
+    TEST(ShapeInteractionsSphereContains, ObbInsideSphere)
+    {
+        const Sphere sphere{{0.0f, 0.0f, 0.0f}, 5.0f};
+        const Obb inside{{0.0f, 0.0f, 0.0f}, {1.0f, 1.5f, 2.0f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+        const Obb outside{{4.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}, math::quat{1.0f, 0.0f, 0.0f, 0.0f}};
+
+        EXPECT_TRUE(Contains(sphere, inside));
+        EXPECT_TRUE(!Contains(sphere, outside));
+    }
+
+    TEST(ShapeInteractionsSphereContains, SphereInsideSphere)
+    {
+        const Sphere outer{{0.0f, 0.0f, 0.0f}, 3.0f};
+        const Sphere inner_ok{{1.0f, 0.0f, 0.0f}, 1.0f};
+        const Sphere inner_fail{{2.5f, 0.0f, 0.0f}, 1.0f};
+
+        EXPECT_TRUE(Contains(outer, inner_ok));
+        EXPECT_TRUE(!Contains(outer, inner_fail));
+    }
+} // namespace engine::geometry
+


### PR DESCRIPTION
## Summary
- implement intersection routines between spheres and cylinders, ellipsoids, OBBs, segments, and spheres, and add containment predicates for sphere relationships
- fix quaternion handling in auxiliary geometry utilities and include shape interaction headers for octree queries
- add a dedicated sphere interaction gtest target covering intersection and containment cases

## Testing
- ctest -R engine_geometry_shape_interactions_tests --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68df036500248320bfa805d89e45f5b3