### PR TITLE
Fix cylinder–OBB intersection false positives

### DIFF
--- a/engine/geometry/tests/test_shape_interactions.cpp
+++ b/engine/geometry/tests/test_shape_interactions.cpp
@@ -293,11 +293,13 @@ namespace engine::geometry
     TEST(CylinderIntersection, CylinderObb)
     {
         const Cylinder cyl{{0, 0, 0}, {0, 0, 1}, 1.0f, 1.5f};
-        const Obb overlapping{{0, 0, 0}, {0.5f, 0.5f, 0.5f}, math::quat{1, 0, 0, 0}};
+        const Obb centered_box{{0, 0, 0}, {0.5f, 0.5f, 0.5f}, math::quat{1, 0, 0, 0}};
         const Obb separated{{5, 0, 0}, {0.5f, 0.5f, 0.5f}, math::quat{1, 0, 0, 0}};
+        const Cylinder separated_axial{{0, 0, 2}, {0, 0, 1}, 1.0f, 0.5f};
 
-        EXPECT_TRUE(Intersects(cyl, overlapping));
+        EXPECT_TRUE(Intersects(cyl, centered_box));
         EXPECT_FALSE(Intersects(cyl, separated));
+        EXPECT_FALSE(Intersects(separated_axial, centered_box));
     }
 
     TEST(CylinderIntersection, CylinderPlane)


### PR DESCRIPTION
## Summary
- add a closest-point query between a segment and an axis-aligned box to evaluate cylinder axes in OBB space
- require axial overlap and use the closest pair to measure radial clearance for cylinder–OBB intersection tests
- add a regression test that exercises a cylinder axially separated from an OBB

## Testing
- ctest --test-dir build -R engine_geometry_shape_interactions_tests --output-on-failure *(fails: TriangleIntersection.TriangleTriangle, EdgeCases.BoundaryTouching)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b29d77788320a0f596822fb648c5