### PR TITLE
docs: align README files with repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
-# Project Overview
+# Test Engine Workspace
 
-## Purpose
-- Root of the engine workspace.
+The `Test` repository hosts a modular real-time engine prototype. The tree is organised around a CMake build driven core (`engine/`), tooling (`python/`, `scripts/`), and project documentation (`docs/`).
 
-### Subdirectories
-- `.git/` – .git resources.
-- `.idea/` – .idea resources.
-- `docs/` – Project documentation hub.
-- `engine/` – Engine source tree.
-- `python/` – Python bindings and tools.
-- `scripts/` – Automation scripts.
-- `third_party/` – External dependencies.
+## Top-level Layout
+- `docs/` – Design notes and API references that describe the evolving architecture.
+- `engine/` – C++ engine source organised by subsystem (animation, rendering, physics, etc.).
+- `python/` – Python bindings and companion utilities for automation and prototyping.
+- `scripts/` – Developer tooling for builds and continuous integration jobs.
+- `third_party/` – External dependencies vendored into the workspace (currently GoogleTest).
+- `CMakeLists.txt` – Root CMake project file that wires the modular subprojects together.
+- `CODING_STYLE.md` – Canonical formatting and style conventions for contributions.
 
-### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `CODING_STYLE.md` – Project coding style guide.
+## Build Requirements
+The project is configured with CMake. To configure and build the workspace:
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Tests are provided via GoogleTest. Once the project is built, execute `ctest --test-dir build` to run the available suites.
+
+_Last updated: 2025-10-05_

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,11 @@
-# Docs
+# Documentation Hub
 
-## Purpose
-- Project documentation hub.
+The `docs/` subtree aggregates written documentation for the engine project.
 
-### Subdirectories
-- `api/` – API references.
-- `design/` – Architecture documentation.
+## Structure
+- `api/` – High-level API references and module descriptions.
+- `design/` – Architectural sketches, diagrams, and exploratory design documents.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+Each nested directory provides its own README for finer-grained navigation.
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Expand documentation topics as systems evolve.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+_Last updated: 2025-10-05_

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,13 +1,8 @@
 # Api
 
-## Purpose
-- Project documentation hub.
-- API references.
+_Path: `docs/api`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Expand documentation topics as systems evolve.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,13 +1,8 @@
 # Design
 
-## Purpose
-- Project documentation hub.
-- Architecture documentation.
+_Path: `docs/design`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Expand documentation topics as systems evolve.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,29 +1,23 @@
-# Engine
+# Engine Source Tree
 
-## Purpose
-- Engine source tree.
+The `engine/` subtree contains the core C++ implementation of the engine. Each subsystem is isolated in its own directory with a matching README that summarises its state.
 
-### Subdirectories
-- `animation/` – Animation systems and tooling.
-- `assets/` – Asset management and import pipelines.
-- `compute/` – GPU and parallel compute utilities.
-- `core/` – Core runtime services.
-- `geometry/` – Geometric primitives and operations.
-- `io/` – Input/output subsystems.
-- `math/` – Math helpers shared across the engine.
-- `physics/` – Physics simulation utilities.
-- `platform/` – Platform abstraction layers.
-- `rendering/` – Rendering pipeline and resources.
-- `runtime/` – Runtime glue and integration.
-- `scene/` – Scene graph and component systems.
-- `tests/` – Automated test suites.
-- `tools/` – Developer tooling.
+## Subsystems
+- `animation/` – Rigging, deformation, and animation runtime experiments.
+- `assets/` – Asset pipelines, sample content, and shader packaging.
+- `compute/` – Heterogeneous compute backends (CUDA and generic dispatch infrastructure).
+- `core/` – Foundational runtime services, configuration, diagnostics, and ECS primitives.
+- `geometry/` – Mesh processing, topology utilities, and geometric algorithms.
+- `io/` – Import/export modules and caching layers for content.
+- `math/` – Shared mathematical utilities.
+- `physics/` – Collision detection and dynamics scaffolding.
+- `platform/` – Abstractions for windowing, input, and file systems.
+- `rendering/` – Rendering pipeline layers, material systems, and backend integrations.
+- `runtime/` – Application glue that stitches systems together.
+- `scene/` – Scene graph, component registration, and serialization.
+- `tests/` – Unit, integration, and performance test suites organised by subsystem.
+- `tools/` – Developer tooling (profilers, content pipelines, and editor stubs).
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
+A top-level `CMakeLists.txt` exposes each subsystem to the global build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+_Last updated: 2025-10-05_

--- a/engine/animation/README.md
+++ b/engine/animation/README.md
@@ -1,22 +1,21 @@
 # Animation
 
-## Purpose
-- Engine source tree.
-- Animation systems and tooling.
+_Path: `engine/animation`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `deformation/` – Deformation workflows.
-- `include/` – Public headers.
-- `rigging/` – Rigging helpers.
-- `skinning/` – Skinning logic.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `deformation/` – documented in its own README; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `rigging/` – documented in its own README; contains 1 file.
+- `skinning/` – documented in its own README; contains 1 file.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/animation/deformation/README.md
+++ b/engine/animation/deformation/README.md
@@ -1,13 +1,8 @@
 # Deformation
 
-## Purpose
-- Engine source tree.
-- Animation systems and tooling.
-- Deformation workflows.
+_Path: `engine/animation/deformation`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/animation/include/engine/animation/README.md
+++ b/engine/animation/include/engine/animation/README.md
@@ -1,13 +1,12 @@
 # Animation
 
-## Purpose
-- Engine source tree.
-- Animation systems and tooling.
-- Public headers.
+_Path: `engine/animation/include/engine/animation`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/animation/rigging/README.md
+++ b/engine/animation/rigging/README.md
@@ -1,13 +1,8 @@
 # Rigging
 
-## Purpose
-- Engine source tree.
-- Animation systems and tooling.
-- Rigging helpers.
+_Path: `engine/animation/rigging`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/animation/skinning/README.md
+++ b/engine/animation/skinning/README.md
@@ -1,13 +1,8 @@
 # Skinning
 
-## Purpose
-- Engine source tree.
-- Animation systems and tooling.
-- Skinning logic.
+_Path: `engine/animation/skinning`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/animation/src/README.md
+++ b/engine/animation/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Animation systems and tooling.
-- Source files.
+_Path: `engine/animation/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/animation/tests/README.md
+++ b/engine/animation/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Animation systems and tooling.
-- Automated test suites.
+_Path: `engine/animation/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/assets/README.md
+++ b/engine/assets/README.md
@@ -1,21 +1,20 @@
 # Assets
 
-## Purpose
-- Engine source tree.
-- Asset management and import pipelines.
+_Path: `engine/assets`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `include/` – Public headers.
-- `samples/` – Sample content.
-- `shaders/` – Shader code.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `include/` – contains 1 subdirectory.
+- `samples/` – documented in its own README; contains 1 file.
+- `shaders/` – documented in its own README; contains 1 file.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/assets/include/engine/assets/README.md
+++ b/engine/assets/include/engine/assets/README.md
@@ -1,13 +1,12 @@
 # Assets
 
-## Purpose
-- Engine source tree.
-- Asset management and import pipelines.
-- Public headers.
+_Path: `engine/assets/include/engine/assets`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/assets/samples/README.md
+++ b/engine/assets/samples/README.md
@@ -1,13 +1,8 @@
 # Samples
 
-## Purpose
-- Engine source tree.
-- Asset management and import pipelines.
-- Sample content.
+_Path: `engine/assets/samples`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/assets/shaders/README.md
+++ b/engine/assets/shaders/README.md
@@ -1,14 +1,8 @@
 # Shaders
 
-## Purpose
-- Engine source tree.
-- Asset management and import pipelines.
-- Shader code.
+_Path: `engine/assets/shaders`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Provide representative shader examples.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/assets/src/README.md
+++ b/engine/assets/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Asset management and import pipelines.
-- Source files.
+_Path: `engine/assets/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/assets/tests/README.md
+++ b/engine/assets/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Asset management and import pipelines.
-- Automated test suites.
+_Path: `engine/assets/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/compute/README.md
+++ b/engine/compute/README.md
@@ -1,19 +1,19 @@
 # Compute
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
+_Path: `engine/compute`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `cuda/` – CUDA powered compute.
-- `include/` – Public headers.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `cuda/` – documented in its own README; contains 3 subdirectories; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/compute/cuda/README.md
+++ b/engine/compute/cuda/README.md
@@ -1,19 +1,18 @@
 # Cuda
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
-- CUDA powered compute.
+_Path: `engine/compute/cuda`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `include/` – Public headers.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `include/` – contains 1 subdirectory.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/compute/cuda/include/engine/compute/cuda/README.md
+++ b/engine/compute/cuda/include/engine/compute/cuda/README.md
@@ -1,14 +1,12 @@
 # Cuda
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
-- CUDA powered compute.
-- Public headers.
+_Path: `engine/compute/cuda/include/engine/compute/cuda`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/compute/cuda/src/README.md
+++ b/engine/compute/cuda/src/README.md
@@ -1,14 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
-- CUDA powered compute.
-- Source files.
+_Path: `engine/compute/cuda/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/compute/cuda/tests/README.md
+++ b/engine/compute/cuda/tests/README.md
@@ -1,15 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
-- CUDA powered compute.
-- Automated test suites.
+_Path: `engine/compute/cuda/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/compute/include/engine/compute/README.md
+++ b/engine/compute/include/engine/compute/README.md
@@ -1,13 +1,12 @@
 # Compute
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
-- Public headers.
+_Path: `engine/compute/include/engine/compute`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/compute/src/README.md
+++ b/engine/compute/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
-- Source files.
+_Path: `engine/compute/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/compute/tests/README.md
+++ b/engine/compute/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- GPU and parallel compute utilities.
-- Automated test suites.
+_Path: `engine/compute/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/core/README.md
+++ b/engine/core/README.md
@@ -1,27 +1,26 @@
 # Core
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `application/` – Application resources.
-- `configuration/` – Configuration resources.
-- `diagnostics/` – Diagnostics resources.
-- `ecs/` – ECS resources.
-- `include/` – Public headers.
-- `memory/` – Memory resources.
-- `parallel/` – Parallel resources.
-- `plugin/` – Plugin resources.
-- `runtime/` – Runtime glue and integration.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `application/` – documented in its own README; contains 1 file.
+- `configuration/` – documented in its own README; contains 1 file.
+- `diagnostics/` – documented in its own README; contains 1 file.
+- `ecs/` – documented in its own README; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `memory/` – documented in its own README; contains 1 file.
+- `parallel/` – documented in its own README; contains 1 file.
+- `plugin/` – documented in its own README; contains 1 file.
+- `runtime/` – documented in its own README; contains 1 file.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/core/application/README.md
+++ b/engine/core/application/README.md
@@ -1,12 +1,8 @@
 # Application
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core/application`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/configuration/README.md
+++ b/engine/core/configuration/README.md
@@ -1,12 +1,8 @@
 # Configuration
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core/configuration`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/diagnostics/README.md
+++ b/engine/core/diagnostics/README.md
@@ -1,12 +1,8 @@
 # Diagnostics
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core/diagnostics`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/ecs/README.md
+++ b/engine/core/ecs/README.md
@@ -1,12 +1,8 @@
 # Ecs
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core/ecs`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/include/engine/core/README.md
+++ b/engine/core/include/engine/core/README.md
@@ -1,13 +1,12 @@
 # Core
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
-- Public headers.
+_Path: `engine/core/include/engine/core`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/core/memory/README.md
+++ b/engine/core/memory/README.md
@@ -1,12 +1,8 @@
 # Memory
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core/memory`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/parallel/README.md
+++ b/engine/core/parallel/README.md
@@ -1,12 +1,8 @@
 # Parallel
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core/parallel`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/plugin/README.md
+++ b/engine/core/plugin/README.md
@@ -1,12 +1,8 @@
 # Plugin
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
+_Path: `engine/core/plugin`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/runtime/README.md
+++ b/engine/core/runtime/README.md
@@ -1,13 +1,8 @@
 # Runtime
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
-- Runtime glue and integration.
+_Path: `engine/core/runtime`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/core/src/README.md
+++ b/engine/core/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
-- Source files.
+_Path: `engine/core/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/core/tests/README.md
+++ b/engine/core/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Core runtime services.
-- Automated test suites.
+_Path: `engine/core/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/geometry/README.md
+++ b/engine/geometry/README.md
@@ -1,5 +1,25 @@
-# engine/geometry
+# Geometry
 
-This directory collects the C++ engine source tree, the geometry subsystem for meshes, primitives, and spatial algorithms.
-In addition to the spatial primitives, it now exposes the property registry that tracks per-element attributes without relying on exceptions, making it suitable for downstream mesh processing tools.
-Future additions should place additional contributions to the geometry subsystem for meshes, primitives, and spatial algorithms here to keep related work easy to discover.
+_Path: `engine/geometry`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
+
+### Subdirectories
+
+- `csg/` – documented in its own README; contains 1 file.
+- `decimation/` – documented in its own README; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `mesh/` – documented in its own README; contains 1 file.
+- `src/` – documented in its own README; contains 6 subdirectories; contains 1 file.
+- `surfaces/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 8 files.
+- `topology/` – documented in its own README; contains 1 file.
+- `uv/` – documented in its own README; contains 1 file.
+- `volumetric/` – documented in its own README; contains 1 file.
+
+### Files
+
+- `CMakeLists.txt` – Text resource.

--- a/engine/geometry/csg/README.md
+++ b/engine/geometry/csg/README.md
@@ -1,13 +1,8 @@
 # Csg
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Constructive solid geometry routines.
+_Path: `engine/geometry/csg`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/geometry/decimation/README.md
+++ b/engine/geometry/decimation/README.md
@@ -1,13 +1,8 @@
 # Decimation
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Geometry simplification pipelines.
+_Path: `engine/geometry/decimation`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/geometry/include/engine/geometry/README.md
+++ b/engine/geometry/include/engine/geometry/README.md
@@ -1,6 +1,23 @@
-# engine/geometry/include/engine/geometry
+# Geometry
 
-This directory collects the C++ engine source tree, the geometry subsystem for meshes, primitives, and spatial algorithms, public headers defining the subsystem API.
-The type-erased attribute system lives in `property_registry.hpp` and `property_set.hpp`, enabling structured property access shared by mesh, graph, and point-set data structures.
-General-purpose combinatorial graphs are available through `graph/graph.hpp`, and unstructured point sets are modelled by `point_cloud.hpp`, both exposing property accessors consistent with `mesh/halfedge_mesh.hpp`.
-Future additions should place additional contributions to public headers defining the subsystem API here to keep related work easy to discover.
+_Path: `engine/geometry/include/engine/geometry`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
+
+### Subdirectories
+
+- `graph/` – contains 1 file.
+- `mesh/` – contains 1 file.
+- `octree/` – contains 1 file.
+- `point_cloud/` – contains 1 file.
+- `properties/` – contains 3 files.
+- `shapes/` – documented in its own README; contains 10 files.
+- `utils/` – contains 6 files.
+
+### Files
+
+- `api.hpp` – C++ header.
+- `shapes.hpp` – C++ header.

--- a/engine/geometry/include/engine/geometry/shapes/README.md
+++ b/engine/geometry/include/engine/geometry/shapes/README.md
@@ -1,23 +1,21 @@
 # Shapes
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Public headers.
-- Shape-specific utilities.
+_Path: `engine/geometry/include/engine/geometry/shapes`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `aabb.hpp` – Header for Aabb.
-- `cylinder.hpp` – Header for Cylinder.
-- `ellipsoid.hpp` – Header for Ellipsoid.
-- `line.hpp` – Header for Line.
-- `obb.hpp` – Header for Obb.
-- `plane.hpp` – Header for Plane.
-- `ray.hpp` – Header for Ray.
-- `segment.hpp` – Header for Segment.
-- `sphere.hpp` – Header for Sphere.
-- `triangle.hpp` – Header for Triangle.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `aabb.hpp` – C++ header.
+- `cylinder.hpp` – C++ header.
+- `ellipsoid.hpp` – C++ header.
+- `line.hpp` – C++ header.
+- `obb.hpp` – C++ header.
+- `plane.hpp` – C++ header.
+- `ray.hpp` – C++ header.
+- `segment.hpp` – C++ header.
+- `sphere.hpp` – C++ header.
+- `triangle.hpp` – C++ header.

--- a/engine/geometry/mesh/README.md
+++ b/engine/geometry/mesh/README.md
@@ -1,13 +1,8 @@
 # Mesh
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Mesh processing helpers.
+_Path: `engine/geometry/mesh`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/geometry/src/README.md
+++ b/engine/geometry/src/README.md
@@ -1,17 +1,21 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Source files.
+_Path: `engine/geometry/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `shapes/` – Shape-specific utilities.
+
+- `graph/` – contains 1 file.
+- `mesh/` – contains 1 file.
+- `point_cloud/` – contains 1 file.
+- `properties/` – contains 2 files.
+- `shapes/` – documented in its own README; contains 10 files.
+- `utils/` – contains 1 file.
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/geometry/src/shapes/README.md
+++ b/engine/geometry/src/shapes/README.md
@@ -1,23 +1,21 @@
 # Shapes
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Source files.
-- Shape-specific utilities.
+_Path: `engine/geometry/src/shapes`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `aabb.cpp` – Implementation for Aabb.
-- `cylinder.cpp` – Implementation for Cylinder.
-- `ellipsoid.cpp` – Implementation for Ellipsoid.
-- `line.cpp` – Implementation for Line.
-- `obb.cpp` – Implementation for Obb.
-- `plane.cpp` – Implementation for Plane.
-- `ray.cpp` – Implementation for Ray.
-- `segment.cpp` – Implementation for Segment.
-- `sphere.cpp` – Implementation for Sphere.
-- `triangle.cpp` – Implementation for Triangle.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `aabb.cpp` – C++ source file.
+- `cylinder.cpp` – C++ source file.
+- `ellipsoid.cpp` – C++ source file.
+- `line.cpp` – C++ source file.
+- `obb.cpp` – C++ source file.
+- `plane.cpp` – C++ source file.
+- `ray.cpp` – C++ source file.
+- `segment.cpp` – C++ source file.
+- `sphere.cpp` – C++ source file.
+- `triangle.cpp` – C++ source file.

--- a/engine/geometry/surfaces/README.md
+++ b/engine/geometry/surfaces/README.md
@@ -1,13 +1,8 @@
 # Surfaces
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Surface generation helpers.
+_Path: `engine/geometry/surfaces`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/geometry/tests/README.md
+++ b/engine/geometry/tests/README.md
@@ -1,5 +1,19 @@
-# engine/geometry/tests
+# Tests
 
-This directory collects the C++ engine source tree, the geometry subsystem for meshes, primitives, and spatial algorithms, automated tests validating this layer.
-It now includes coverage for the property registry to guarantee optional-based lookup semantics, default value propagation, and removal bookkeeping.
-Future additions should place additional contributions to automated tests validating this layer here to keep related work easy to discover.
+_Path: `engine/geometry/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
+
+### Files
+
+- `CMakeLists.txt` – Text resource.
+- `test_graph.cpp` – C++ source file.
+- `test_halfedge_mesh.cpp` – C++ source file.
+- `test_module.cpp` – C++ source file.
+- `test_point_cloud.cpp` – C++ source file.
+- `test_property_registry.cpp` – C++ source file.
+- `test_shape_interactions.cpp` – C++ source file.
+- `test_shapes.cpp` – C++ source file.

--- a/engine/geometry/topology/README.md
+++ b/engine/geometry/topology/README.md
@@ -1,13 +1,8 @@
 # Topology
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Topology utilities.
+_Path: `engine/geometry/topology`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/geometry/uv/README.md
+++ b/engine/geometry/uv/README.md
@@ -1,13 +1,8 @@
 # Uv
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- UV mapping utilities.
+_Path: `engine/geometry/uv`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/geometry/volumetric/README.md
+++ b/engine/geometry/volumetric/README.md
@@ -1,13 +1,8 @@
 # Volumetric
 
-## Purpose
-- Engine source tree.
-- Geometric primitives and operations.
-- Volume processing utilities.
+_Path: `engine/geometry/volumetric`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/io/README.md
+++ b/engine/io/README.md
@@ -1,22 +1,21 @@
 # Io
 
-## Purpose
-- Engine source tree.
-- Input/output subsystems.
+_Path: `engine/io`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `cache/` – Caching layers.
-- `exporters/` – Asset exporters.
-- `importers/` – Asset importers.
-- `include/` – Public headers.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `cache/` – documented in its own README; contains 1 file.
+- `exporters/` – documented in its own README; contains 1 file.
+- `importers/` – documented in its own README; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/io/cache/README.md
+++ b/engine/io/cache/README.md
@@ -1,13 +1,8 @@
 # Cache
 
-## Purpose
-- Engine source tree.
-- Input/output subsystems.
-- Caching layers.
+_Path: `engine/io/cache`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/io/exporters/README.md
+++ b/engine/io/exporters/README.md
@@ -1,13 +1,8 @@
 # Exporters
 
-## Purpose
-- Engine source tree.
-- Input/output subsystems.
-- Asset exporters.
+_Path: `engine/io/exporters`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/io/importers/README.md
+++ b/engine/io/importers/README.md
@@ -1,13 +1,8 @@
 # Importers
 
-## Purpose
-- Engine source tree.
-- Input/output subsystems.
-- Asset importers.
+_Path: `engine/io/importers`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/io/include/engine/io/README.md
+++ b/engine/io/include/engine/io/README.md
@@ -1,13 +1,12 @@
 # Io
 
-## Purpose
-- Engine source tree.
-- Input/output subsystems.
-- Public headers.
+_Path: `engine/io/include/engine/io`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/io/src/README.md
+++ b/engine/io/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Input/output subsystems.
-- Source files.
+_Path: `engine/io/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/io/tests/README.md
+++ b/engine/io/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Input/output subsystems.
-- Automated test suites.
+_Path: `engine/io/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/math/README.md
+++ b/engine/math/README.md
@@ -1,17 +1,17 @@
 # Math
 
-## Purpose
-- Engine source tree.
-- Math helpers shared across the engine.
+_Path: `engine/math`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `include/` – Public headers.
-- `tests/` – Automated test suites.
+
+- `include/` – contains 1 subdirectory.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/math/include/engine/math/README.md
+++ b/engine/math/include/engine/math/README.md
@@ -1,20 +1,19 @@
 # Math
 
-## Purpose
-- Engine source tree.
-- Math helpers shared across the engine.
-- Public headers.
+_Path: `engine/math/include/engine/math`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `common.hpp` – Header for Common.
-- `math.hpp` – Header for Math.
-- `matrix.hpp` – Header for Matrix.
-- `quaternion.hpp` – Header for Quaternion.
-- `vector.hpp` – Header for Vector.
-- `utils.hpp` – Header for Utilities.'
-- `utils_camera.hpp` – Header for Camera Utilities.
-- `utils_rotation.hpp` – Header for Rotation Utilities.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `common.hpp` – C++ header.
+- `math.hpp` – C++ header.
+- `matrix.hpp` – C++ header.
+- `quaternion.hpp` – C++ header.
+- `utils.hpp` – C++ header.
+- `utils_camera.hpp` – C++ header.
+- `utils_rotation.hpp` – C++ header.
+- `vector.hpp` – C++ header.

--- a/engine/math/tests/README.md
+++ b/engine/math/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Math helpers shared across the engine.
-- Automated test suites.
+_Path: `engine/math/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_math.cpp` – Implementation for Test Math.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_math.cpp` – C++ source file.

--- a/engine/physics/README.md
+++ b/engine/physics/README.md
@@ -1,21 +1,20 @@
 # Physics
 
-## Purpose
-- Engine source tree.
-- Physics simulation utilities.
+_Path: `engine/physics`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `collision/` – Collision resources.
-- `dynamics/` – Dynamics resources.
-- `include/` – Public headers.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `collision/` – documented in its own README; contains 1 file.
+- `dynamics/` – documented in its own README; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/physics/collision/README.md
+++ b/engine/physics/collision/README.md
@@ -1,12 +1,8 @@
 # Collision
 
-## Purpose
-- Engine source tree.
-- Physics simulation utilities.
+_Path: `engine/physics/collision`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/physics/dynamics/README.md
+++ b/engine/physics/dynamics/README.md
@@ -1,12 +1,8 @@
 # Dynamics
 
-## Purpose
-- Engine source tree.
-- Physics simulation utilities.
+_Path: `engine/physics/dynamics`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/physics/include/engine/physics/README.md
+++ b/engine/physics/include/engine/physics/README.md
@@ -1,13 +1,12 @@
 # Physics
 
-## Purpose
-- Engine source tree.
-- Physics simulation utilities.
-- Public headers.
+_Path: `engine/physics/include/engine/physics`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/physics/src/README.md
+++ b/engine/physics/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Physics simulation utilities.
-- Source files.
+_Path: `engine/physics/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/physics/tests/README.md
+++ b/engine/physics/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Physics simulation utilities.
-- Automated test suites.
+_Path: `engine/physics/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/platform/README.md
+++ b/engine/platform/README.md
@@ -1,22 +1,21 @@
 # Platform
 
-## Purpose
-- Engine source tree.
-- Platform abstraction layers.
+_Path: `engine/platform`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `filesystem/` – Filesystem abstractions.
-- `include/` – Public headers.
-- `input/` – Input handling.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
-- `windowing/` – Window system integration.
+
+- `filesystem/` – documented in its own README; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `input/` – documented in its own README; contains 1 file.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
+- `windowing/` – documented in its own README; contains 1 file.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/platform/filesystem/README.md
+++ b/engine/platform/filesystem/README.md
@@ -1,13 +1,8 @@
 # Filesystem
 
-## Purpose
-- Engine source tree.
-- Platform abstraction layers.
-- Filesystem abstractions.
+_Path: `engine/platform/filesystem`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/platform/include/engine/platform/README.md
+++ b/engine/platform/include/engine/platform/README.md
@@ -1,13 +1,12 @@
 # Platform
 
-## Purpose
-- Engine source tree.
-- Platform abstraction layers.
-- Public headers.
+_Path: `engine/platform/include/engine/platform`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/platform/input/README.md
+++ b/engine/platform/input/README.md
@@ -1,13 +1,8 @@
 # Input
 
-## Purpose
-- Engine source tree.
-- Platform abstraction layers.
-- Input handling.
+_Path: `engine/platform/input`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/platform/src/README.md
+++ b/engine/platform/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Platform abstraction layers.
-- Source files.
+_Path: `engine/platform/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/platform/tests/README.md
+++ b/engine/platform/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Platform abstraction layers.
-- Automated test suites.
+_Path: `engine/platform/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/platform/windowing/README.md
+++ b/engine/platform/windowing/README.md
@@ -1,13 +1,8 @@
 # Windowing
 
-## Purpose
-- Engine source tree.
-- Platform abstraction layers.
-- Window system integration.
+_Path: `engine/platform/windowing`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/README.md
+++ b/engine/rendering/README.md
@@ -1,26 +1,25 @@
 # Rendering
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
+_Path: `engine/rendering`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `backend/` – Graphics API backends.
-- `include/` – Public headers.
-- `lighting/` – Lighting systems.
-- `materials/` – Material definitions and shaders.
-- `passes/` – Render pass scheduling.
-- `pipeline/` – Render pipeline configuration.
-- `resources/` – GPU resource management.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
-- `visibility/` – Visibility resources.
+
+- `backend/` – documented in its own README; contains 4 subdirectories; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `lighting/` – documented in its own README; contains 1 file.
+- `materials/` – documented in its own README; contains 2 subdirectories; contains 1 file.
+- `passes/` – documented in its own README; contains 1 file.
+- `pipeline/` – documented in its own README; contains 1 file.
+- `resources/` – documented in its own README; contains 2 subdirectories; contains 1 file.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
+- `visibility/` – documented in its own README; contains 1 file.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/rendering/backend/README.md
+++ b/engine/rendering/backend/README.md
@@ -1,20 +1,15 @@
 # Backend
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Graphics API backends.
+_Path: `engine/rendering/backend`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `directx12/` – DirectX 12 backend glue.
-- `metal/` – Metal backend glue.
-- `opengl/` – OpenGL backend glue.
-- `vulkan/` – Vulkan backend glue.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `directx12/` – documented in its own README; contains 1 file.
+- `metal/` – documented in its own README; contains 1 file.
+- `opengl/` – documented in its own README; contains 1 file.
+- `vulkan/` – documented in its own README; contains 1 file.

--- a/engine/rendering/backend/directx12/README.md
+++ b/engine/rendering/backend/directx12/README.md
@@ -1,14 +1,8 @@
 # Directx12
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Graphics API backends.
-- DirectX 12 backend glue.
+_Path: `engine/rendering/backend/directx12`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/backend/metal/README.md
+++ b/engine/rendering/backend/metal/README.md
@@ -1,14 +1,8 @@
 # Metal
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Graphics API backends.
-- Metal backend glue.
+_Path: `engine/rendering/backend/metal`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/backend/opengl/README.md
+++ b/engine/rendering/backend/opengl/README.md
@@ -1,14 +1,8 @@
 # Opengl
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Graphics API backends.
-- OpenGL backend glue.
+_Path: `engine/rendering/backend/opengl`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/backend/vulkan/README.md
+++ b/engine/rendering/backend/vulkan/README.md
@@ -1,14 +1,8 @@
 # Vulkan
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Graphics API backends.
-- Vulkan backend glue.
+_Path: `engine/rendering/backend/vulkan`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/include/engine/rendering/README.md
+++ b/engine/rendering/include/engine/rendering/README.md
@@ -1,13 +1,12 @@
 # Rendering
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Public headers.
+_Path: `engine/rendering/include/engine/rendering`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/rendering/lighting/README.md
+++ b/engine/rendering/lighting/README.md
@@ -1,13 +1,8 @@
 # Lighting
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Lighting systems.
+_Path: `engine/rendering/lighting`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/materials/README.md
+++ b/engine/rendering/materials/README.md
@@ -1,18 +1,13 @@
 # Materials
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Material definitions and shaders.
+_Path: `engine/rendering/materials`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `shaders/` – Shader code.
-- `textures/` – Texture assets.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `shaders/` – documented in its own README; contains 3 subdirectories; contains 1 file.
+- `textures/` – documented in its own README; contains 1 file.

--- a/engine/rendering/materials/shaders/README.md
+++ b/engine/rendering/materials/shaders/README.md
@@ -1,21 +1,14 @@
 # Shaders
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Material definitions and shaders.
-- Shader code.
+_Path: `engine/rendering/materials/shaders`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `common/` – Shared shader code.
-- `glsl/` – GLSL shader code.
-- `hlsl/` – HLSL shader code.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Provide representative shader examples.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `common/` – documented in its own README; contains 1 file.
+- `glsl/` – documented in its own README; contains 1 file.
+- `hlsl/` – documented in its own README; contains 1 file.

--- a/engine/rendering/materials/shaders/common/README.md
+++ b/engine/rendering/materials/shaders/common/README.md
@@ -1,16 +1,8 @@
 # Common
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Material definitions and shaders.
-- Shader code.
-- Shared shader code.
+_Path: `engine/rendering/materials/shaders/common`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Provide representative shader examples.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/materials/shaders/glsl/README.md
+++ b/engine/rendering/materials/shaders/glsl/README.md
@@ -1,16 +1,8 @@
 # Glsl
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Material definitions and shaders.
-- Shader code.
-- GLSL shader code.
+_Path: `engine/rendering/materials/shaders/glsl`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Provide representative shader examples.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/materials/shaders/hlsl/README.md
+++ b/engine/rendering/materials/shaders/hlsl/README.md
@@ -1,16 +1,8 @@
 # Hlsl
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Material definitions and shaders.
-- Shader code.
-- HLSL shader code.
+_Path: `engine/rendering/materials/shaders/hlsl`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Provide representative shader examples.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/materials/textures/README.md
+++ b/engine/rendering/materials/textures/README.md
@@ -1,14 +1,8 @@
 # Textures
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Material definitions and shaders.
-- Texture assets.
+_Path: `engine/rendering/materials/textures`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/passes/README.md
+++ b/engine/rendering/passes/README.md
@@ -1,13 +1,8 @@
 # Passes
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Render pass scheduling.
+_Path: `engine/rendering/passes`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/pipeline/README.md
+++ b/engine/rendering/pipeline/README.md
@@ -1,13 +1,8 @@
 # Pipeline
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Render pipeline configuration.
+_Path: `engine/rendering/pipeline`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/resources/README.md
+++ b/engine/rendering/resources/README.md
@@ -1,18 +1,13 @@
 # Resources
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- GPU resource management.
+_Path: `engine/rendering/resources`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `buffers/` – Buffer resources.
-- `samplers/` – Sampler resources.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `buffers/` – documented in its own README; contains 1 file.
+- `samplers/` – documented in its own README; contains 1 file.

--- a/engine/rendering/resources/buffers/README.md
+++ b/engine/rendering/resources/buffers/README.md
@@ -1,14 +1,8 @@
 # Buffers
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- GPU resource management.
-- Buffer resources.
+_Path: `engine/rendering/resources/buffers`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/resources/samplers/README.md
+++ b/engine/rendering/resources/samplers/README.md
@@ -1,14 +1,8 @@
 # Samplers
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- GPU resource management.
-- Sampler resources.
+_Path: `engine/rendering/resources/samplers`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/rendering/src/README.md
+++ b/engine/rendering/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Source files.
+_Path: `engine/rendering/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/rendering/tests/README.md
+++ b/engine/rendering/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
-- Automated test suites.
+_Path: `engine/rendering/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/rendering/visibility/README.md
+++ b/engine/rendering/visibility/README.md
@@ -1,12 +1,8 @@
 # Visibility
 
-## Purpose
-- Engine source tree.
-- Rendering pipeline and resources.
+_Path: `engine/rendering/visibility`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/runtime/README.md
+++ b/engine/runtime/README.md
@@ -1,18 +1,18 @@
 # Runtime
 
-## Purpose
-- Engine source tree.
-- Runtime glue and integration.
+_Path: `engine/runtime`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `include/` – Public headers.
-- `src/` – Source files.
-- `tests/` – Automated test suites.
+
+- `include/` – contains 1 subdirectory.
+- `src/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/runtime/include/engine/runtime/README.md
+++ b/engine/runtime/include/engine/runtime/README.md
@@ -1,13 +1,12 @@
 # Runtime
 
-## Purpose
-- Engine source tree.
-- Runtime glue and integration.
-- Public headers.
+_Path: `engine/runtime/include/engine/runtime`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/runtime/src/README.md
+++ b/engine/runtime/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Runtime glue and integration.
-- Source files.
+_Path: `engine/runtime/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/runtime/tests/README.md
+++ b/engine/runtime/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Runtime glue and integration.
-- Automated test suites.
+_Path: `engine/runtime/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/scene/README.md
+++ b/engine/scene/README.md
@@ -1,23 +1,22 @@
 # Scene
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
+_Path: `engine/scene`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `components/` – Scene components.
-- `graph/` – Scene graph helpers.
-- `include/` – Public headers.
-- `serialization/` – Serialization helpers.
-- `src/` – Source files.
-- `systems/` – Systems resources.
-- `tests/` – Automated test suites.
+
+- `components/` – documented in its own README; contains 1 file.
+- `graph/` – documented in its own README; contains 1 file.
+- `include/` – contains 1 subdirectory.
+- `serialization/` – documented in its own README; contains 1 file.
+- `src/` – documented in its own README; contains 1 file.
+- `systems/` – documented in its own README; contains 1 file.
+- `tests/` – documented in its own README; contains 2 files.
 
 ### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/engine/scene/components/README.md
+++ b/engine/scene/components/README.md
@@ -1,13 +1,8 @@
 # Components
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
-- Scene components.
+_Path: `engine/scene/components`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/scene/graph/README.md
+++ b/engine/scene/graph/README.md
@@ -1,13 +1,8 @@
 # Graph
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
-- Scene graph helpers.
+_Path: `engine/scene/graph`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/scene/include/engine/scene/README.md
+++ b/engine/scene/include/engine/scene/README.md
@@ -1,13 +1,12 @@
 # Scene
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
-- Public headers.
+_Path: `engine/scene/include/engine/scene`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.hpp` – Header for API.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `api.hpp` – C++ header.

--- a/engine/scene/serialization/README.md
+++ b/engine/scene/serialization/README.md
@@ -1,13 +1,8 @@
 # Serialization
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
-- Serialization helpers.
+_Path: `engine/scene/serialization`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/scene/src/README.md
+++ b/engine/scene/src/README.md
@@ -1,13 +1,12 @@
 # Src
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
-- Source files.
+_Path: `engine/scene/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `api.cpp` – Implementation for API.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `api.cpp` – C++ source file.

--- a/engine/scene/systems/README.md
+++ b/engine/scene/systems/README.md
@@ -1,12 +1,8 @@
 # Systems
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
+_Path: `engine/scene/systems`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/scene/tests/README.md
+++ b/engine/scene/tests/README.md
@@ -1,14 +1,13 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Scene graph and component systems.
-- Automated test suites.
+_Path: `engine/scene/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
-- `test_module.cpp` – Implementation for Test Module.
 
-## TODO
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.
+- `test_module.cpp` – C++ source file.

--- a/engine/tests/README.md
+++ b/engine/tests/README.md
@@ -1,19 +1,14 @@
 # Tests
 
-## Purpose
-- Engine source tree.
-- Automated test suites.
+_Path: `engine/tests`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `integration/` – Integration tests.
-- `performance/` – Performance benchmarks.
-- `unit/` – Unit tests.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Grow the automated coverage for this area.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `integration/` – documented in its own README; contains 1 file.
+- `performance/` – documented in its own README; contains 1 file.
+- `unit/` – documented in its own README; contains 1 file.

--- a/engine/tests/integration/README.md
+++ b/engine/tests/integration/README.md
@@ -1,14 +1,8 @@
 # Integration
 
-## Purpose
-- Engine source tree.
-- Automated test suites.
-- Integration tests.
+_Path: `engine/tests/integration`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/tests/performance/README.md
+++ b/engine/tests/performance/README.md
@@ -1,14 +1,8 @@
 # Performance
 
-## Purpose
-- Engine source tree.
-- Automated test suites.
-- Performance benchmarks.
+_Path: `engine/tests/performance`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/tests/unit/README.md
+++ b/engine/tests/unit/README.md
@@ -1,14 +1,8 @@
 # Unit
 
-## Purpose
-- Engine source tree.
-- Automated test suites.
-- Unit tests.
+_Path: `engine/tests/unit`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Grow the automated coverage for this area.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/tools/README.md
+++ b/engine/tools/README.md
@@ -1,18 +1,14 @@
 # Tools
 
-## Purpose
-- Engine source tree.
-- Developer tooling.
+_Path: `engine/tools`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `editor/` – Editor tooling.
-- `pipelines/` – Content build pipelines.
-- `profiling/` – Performance profiling utilities.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
-
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `editor/` – documented in its own README; contains 1 file.
+- `pipelines/` – documented in its own README; contains 1 file.
+- `profiling/` – documented in its own README; contains 1 file.

--- a/engine/tools/editor/README.md
+++ b/engine/tools/editor/README.md
@@ -1,13 +1,8 @@
 # Editor
 
-## Purpose
-- Engine source tree.
-- Developer tooling.
-- Editor tooling.
+_Path: `engine/tools/editor`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/tools/pipelines/README.md
+++ b/engine/tools/pipelines/README.md
@@ -1,13 +1,8 @@
 # Pipelines
 
-## Purpose
-- Engine source tree.
-- Developer tooling.
-- Content build pipelines.
+_Path: `engine/tools/pipelines`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/engine/tools/profiling/README.md
+++ b/engine/tools/profiling/README.md
@@ -1,13 +1,8 @@
 # Profiling
 
-## Purpose
-- Engine source tree.
-- Developer tooling.
-- Performance profiling utilities.
+_Path: `engine/tools/profiling`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/python/README.md
+++ b/python/README.md
@@ -1,11 +1,9 @@
-# Python
+# Python Tooling
 
-## Purpose
-- Python bindings and tools.
+Python utilities complement the C++ engine. They facilitate automation, experimental scripting, and bindings.
 
-### Subdirectories
-- `engine3g/` – Python-side engine helpers.
+## Layout
+- `engine3g/` – Python package stubs for engine bindings.
+- `tests/` – Automated tests for the Python-facing APIs (currently `test_loader.py`).
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
+_Last updated: 2025-10-05_

--- a/python/engine3g/README.md
+++ b/python/engine3g/README.md
@@ -1,13 +1,13 @@
-# Engine3G
+# Engine3g
 
-## Purpose
-- Python bindings and tools.
-- Python-side engine helpers.
+_Path: `python/engine3g`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `__init__.py` – Python module for Init.
-- `loader.py` – Python module for Loader.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Add usage notes or examples for the listed files.
+- `__init__.py` – Python module.
+- `loader.py` – Python module.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,16 +1,11 @@
-# Scripts
+# Developer Scripts
 
-## Purpose
-- Automation scripts.
+Automation helpers for building and validating the workspace live under `scripts/`.
 
-### Subdirectories
-- `build/` – Build tooling.
-- `ci/` – Continuous integration scripts.
+## Subdirectories
+- `build/` – Scripts and notes for local build workflows.
+- `ci/` – Continuous integration helpers.
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+Top-level scripts complement the CMake build and documentation maintenance tasks.
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+_Last updated: 2025-10-05_

--- a/scripts/build/README.md
+++ b/scripts/build/README.md
@@ -1,12 +1,8 @@
 # Build
 
-## Purpose
-- Automation scripts.
-- Build tooling.
+_Path: `scripts/build`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -1,12 +1,8 @@
 # Ci
 
-## Purpose
-- Automation scripts.
-- Continuous integration scripts.
+_Path: `scripts/ci`_
 
-### Files
-- `.gitkeep` – Placeholder to keep the directory in git.
+_Last updated: 2025-10-05_
 
-## TODO
-- [ ] Replace the placeholder with real content.
-- [ ] Add usage notes or examples for the listed files.
+
+This directory currently contains no tracked artifacts besides this README.

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,11 +1,8 @@
-# Third Party
+# Third-party Dependencies
 
-## Purpose
-- External dependencies.
+External libraries vendored into the repository are tracked here. Each dependency provides its own README for usage details.
 
-### Subdirectories
-- `googletest/` – Googletest resources.
+## Current Dependencies
+- `googletest/` – Upstream GoogleTest source and headers for unit testing.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
+_Last updated: 2025-10-05_

--- a/third_party/googletest/README.md
+++ b/third_party/googletest/README.md
@@ -1,16 +1,17 @@
 # Googletest
 
-## Purpose
-- External dependencies.
+_Path: `third_party/googletest`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Subdirectories
-- `include/` – Public headers.
-- `src/` – Source files.
+
+- `include/` – contains 1 subdirectory.
+- `src/` – documented in its own README; contains 1 file.
 
 ### Files
-- `CMakeLists.txt` – CMake build configuration.
 
-## TODO
-- [ ] Keep this overview up to date with new additions.
-- [ ] Document ownership and responsibilities for each subfolder.
-- [ ] Add usage notes or examples for the listed files.
+- `CMakeLists.txt` – Text resource.

--- a/third_party/googletest/include/gtest/README.md
+++ b/third_party/googletest/include/gtest/README.md
@@ -1,12 +1,12 @@
 # Gtest
 
-## Purpose
-- External dependencies.
-- Public headers.
+_Path: `third_party/googletest/include/gtest`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `gtest.h` – Header for Gtest.
 
-## TODO
-- [ ] Extend the public headers as new APIs emerge.
-- [ ] Add usage notes or examples for the listed files.
+- `gtest.h` – C/C++ header.

--- a/third_party/googletest/src/README.md
+++ b/third_party/googletest/src/README.md
@@ -1,12 +1,12 @@
 # Src
 
-## Purpose
-- External dependencies.
-- Source files.
+_Path: `third_party/googletest/src`_
+
+_Last updated: 2025-10-05_
+
+
+## Contents
 
 ### Files
-- `gtest_main.cpp` – Implementation for Gtest Main.
 
-## TODO
-- [ ] Expand the runtime features supported here.
-- [ ] Add usage notes or examples for the listed files.
+- `gtest_main.cpp` – C++ source file.


### PR DESCRIPTION
## Summary
- refresh the root README with current repository layout and build instructions
- regenerate subsystem README files so each folder documents its present subdirectories and files
- update third-party documentation to reflect the structure of vendored dependencies

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e2cbdb152083209a9d07a3c2a6eb91