### PR TITLE
Add entt-backed scene management API

### DIFF
--- a/engine/scene/CMakeLists.txt
+++ b/engine/scene/CMakeLists.txt
@@ -2,11 +2,13 @@ set(target_name engine_scene)
 
 add_library(${target_name}
     src/api.cpp
+    src/scene.cpp
 )
 
 target_include_directories(${target_name}
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/third_party/entt/single_include
 )
 
 target_compile_definitions(${target_name}

--- a/engine/scene/include/engine/scene/scene.hpp
+++ b/engine/scene/include/engine/scene/scene.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <entt/entt.hpp>
+
+namespace engine::scene {
+
+class Scene;
+
+class Entity {
+public:
+    using id_type = entt::entity;
+
+    Entity() = default;
+    Entity(id_type id, Scene* scene) noexcept;
+
+    [[nodiscard]] bool valid() const noexcept;
+    [[nodiscard]] id_type id() const noexcept;
+
+    [[nodiscard]] Scene& scene() const;
+
+    void reset() noexcept;
+    void destroy();
+
+    template <typename Component, typename... Args>
+    Component& emplace(Args&&... args);
+
+    template <typename Component, typename... Args>
+    Component& emplace_or_replace(Args&&... args);
+
+    template <typename Component>
+    [[nodiscard]] Component& get();
+
+    template <typename Component>
+    [[nodiscard]] const Component& get() const;
+
+    template <typename Component>
+    [[nodiscard]] bool has() const noexcept;
+
+    template <typename Component>
+    void remove() const;
+
+private:
+    friend class Scene;
+
+    id_type id_{entt::null};
+    Scene* scene_{nullptr};
+};
+
+class Scene {
+public:
+    using registry_type = entt::registry;
+    using entity_type = entt::entity;
+
+    Scene();
+    explicit Scene(std::string name);
+
+    [[nodiscard]] std::string_view name() const noexcept;
+    void set_name(std::string name);
+
+    [[nodiscard]] Entity create_entity();
+    void destroy_entity(Entity& entity);
+    void destroy_entity(entity_type entity);
+
+    [[nodiscard]] Entity wrap(entity_type entity) noexcept;
+    [[nodiscard]] bool valid(entity_type entity) const noexcept;
+
+    registry_type& registry() noexcept;
+    const registry_type& registry() const noexcept;
+
+    template <typename... Components>
+    [[nodiscard]] auto view();
+
+    template <typename... Components>
+    [[nodiscard]] auto view() const;
+
+private:
+    registry_type registry_{};
+    std::string name_{};
+};
+
+inline Entity::Entity(id_type id, Scene* scene) noexcept : id_{id}, scene_{scene} {}
+
+inline bool Entity::valid() const noexcept {
+    return scene_ != nullptr && scene_->valid(id_);
+}
+
+inline Entity::id_type Entity::id() const noexcept {
+    return id_;
+}
+
+inline Scene& Entity::scene() const {
+    if (scene_ == nullptr) {
+        throw std::logic_error{"Entity is not associated with a scene"};
+    }
+
+    return *scene_;
+}
+
+inline void Entity::reset() noexcept {
+    id_ = entt::null;
+    scene_ = nullptr;
+}
+
+inline void Entity::destroy() {
+    if (scene_ != nullptr) {
+        scene_->destroy_entity(*this);
+    }
+}
+
+template <typename Component, typename... Args>
+inline Component& Entity::emplace(Args&&... args) {
+    return scene_->registry().template emplace<Component>(id_, std::forward<Args>(args)...);
+}
+
+template <typename Component, typename... Args>
+inline Component& Entity::emplace_or_replace(Args&&... args) {
+    return scene_->registry().template emplace_or_replace<Component>(id_, std::forward<Args>(args)...);
+}
+
+template <typename Component>
+inline Component& Entity::get() {
+    return scene_->registry().template get<Component>(id_);
+}
+
+template <typename Component>
+inline const Component& Entity::get() const {
+    return scene_->registry().template get<Component>(id_);
+}
+
+template <typename Component>
+inline bool Entity::has() const noexcept {
+    return scene_->registry().template any_of<Component>(id_);
+}
+
+template <typename Component>
+inline void Entity::remove() const {
+    scene_->registry().template remove<Component>(id_);
+}
+
+template <typename... Components>
+inline auto Scene::view() {
+    return registry_.template view<Components...>();
+}
+
+template <typename... Components>
+inline auto Scene::view() const {
+    return registry_.template view<Components...>();
+}
+
+}  // namespace engine::scene
+

--- a/engine/scene/src/scene.cpp
+++ b/engine/scene/src/scene.cpp
@@ -1,0 +1,60 @@
+#include "engine/scene/scene.hpp"
+
+#include <utility>
+
+namespace engine::scene {
+
+Scene::Scene() = default;
+
+Scene::Scene(std::string name) : name_{std::move(name)} {}
+
+std::string_view Scene::name() const noexcept {
+    return name_;
+}
+
+void Scene::set_name(std::string name) {
+    name_ = std::move(name);
+}
+
+Entity Scene::create_entity() {
+    const auto entity = registry_.create();
+    return Entity{entity, this};
+}
+
+void Scene::destroy_entity(Entity& entity) {
+    if (entity.scene_ != this) {
+        return;
+    }
+
+    destroy_entity(entity.id_);
+    entity.reset();
+}
+
+void Scene::destroy_entity(entity_type entity) {
+    if (registry_.valid(entity)) {
+        registry_.destroy(entity);
+    }
+}
+
+Entity Scene::wrap(entity_type entity) noexcept {
+    if (!registry_.valid(entity)) {
+        return {};
+    }
+
+    return Entity{entity, this};
+}
+
+bool Scene::valid(entity_type entity) const noexcept {
+    return registry_.valid(entity);
+}
+
+Scene::registry_type& Scene::registry() noexcept {
+    return registry_;
+}
+
+const Scene::registry_type& Scene::registry() const noexcept {
+    return registry_;
+}
+
+}  // namespace engine::scene
+

--- a/engine/scene/tests/test_module.cpp
+++ b/engine/scene/tests/test_module.cpp
@@ -1,8 +1,57 @@
+#include <cstddef>
+
 #include <gtest/gtest.h>
 
 #include "engine/scene/api.hpp"
+#include "engine/scene/scene.hpp"
 
 TEST(SceneModule, ModuleNameMatchesNamespace) {
     EXPECT_EQ(engine::scene::module_name(), "scene");
     EXPECT_STREQ(engine_scene_module_name(), "scene");
+}
+
+namespace {
+
+struct Position {
+    float x{};
+    float y{};
+    float z{};
+};
+
+}  // namespace
+
+TEST(Scene, CreateAndManipulateEntity) {
+    engine::scene::Scene scene{"test"};
+    EXPECT_EQ(scene.name(), "test");
+
+    auto entity = scene.create_entity();
+    EXPECT_TRUE(entity.valid());
+    EXPECT_TRUE(scene.valid(entity.id()));
+
+    auto& position = entity.emplace<Position>(1.0F, 2.0F, 3.0F);
+    EXPECT_FLOAT_EQ(position.x, 1.0F);
+    EXPECT_FLOAT_EQ(position.y, 2.0F);
+    EXPECT_FLOAT_EQ(position.z, 3.0F);
+
+    const auto& const_position = entity.get<Position>();
+    EXPECT_FLOAT_EQ(const_position.x, 1.0F);
+
+    EXPECT_TRUE(entity.has<Position>());
+
+    auto view = scene.view<Position>();
+    ASSERT_EQ(view.size(), 1);
+
+    std::size_t count = 0;
+    for (auto [id, pos] : view.each()) {
+        EXPECT_EQ(id, entity.id());
+        EXPECT_FLOAT_EQ(pos.y, 2.0F);
+        ++count;
+    }
+    EXPECT_EQ(count, 1U);
+
+    entity.remove<Position>();
+    EXPECT_FALSE(entity.has<Position>());
+
+    entity.destroy();
+    EXPECT_FALSE(entity.valid());
 }


### PR DESCRIPTION
## Summary
- add an entt-backed `Scene`/`Entity` API that wraps registry access for ECS usage
- expose helpers for manipulating components and registry views through the new scene interface
- extend scene tests to cover entity lifecycle, component management, and registry views

## Testing
- cmake -S . -B build *(fails: third_party/entt submodule is not populated in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e380b523388320bcfe3149f77bd6cf