### PR TITLE
Improve Transform::from_matrix decomposition

### DIFF
--- a/engine/math/include/engine/math/transform.hpp
+++ b/engine/math/include/engine/math/transform.hpp
@@ -56,49 +56,116 @@ namespace engine::math
     template <typename T>
     ENGINE_MATH_INLINE Transform<T> from_matrix(const Matrix<T, 4, 4>& matrix) noexcept
     {
-        Transform<T> result;
-        result.translation = Vector<T, 3>{matrix[0][3], matrix[1][3], matrix[2][3]};
+        const T zero = detail::zero<T>();
+        const T one = detail::one<T>();
 
-        Vector<T, 3> basis[3];
+        Matrix<T, 4, 4> local = matrix;
+
+        // Normalise the matrix so that w = 1.
+        if (utils::nearly_equal(local[3][3], zero))
+        {
+            return Transform<T>::Identity();
+        }
+
+        if (!utils::nearly_equal(local[3][3], one))
+        {
+            const T inv_w = one / local[3][3];
+            for (std::size_t r = 0; r < 4; ++r)
+            {
+                for (std::size_t c = 0; c < 4; ++c)
+                {
+                    local[r][c] *= inv_w;
+                }
+            }
+        }
+
+        // Clear perspective terms – they cannot be represented by Transform.
+        if (!utils::nearly_equal(local[3][0], zero) || !utils::nearly_equal(local[3][1], zero)
+            || !utils::nearly_equal(local[3][2], zero))
+        {
+            local[3][0] = zero;
+            local[3][1] = zero;
+            local[3][2] = zero;
+            local[3][3] = one;
+        }
+
+        Transform<T> result;
+        result.translation = Vector<T, 3>{local[0][3], local[1][3], local[2][3]};
+        local[0][3] = zero;
+        local[1][3] = zero;
+        local[2][3] = zero;
+
+        Vector<T, 3> row[3] = {
+            Vector<T, 3>{local[0][0], local[0][1], local[0][2]},
+            Vector<T, 3>{local[1][0], local[1][1], local[1][2]},
+            Vector<T, 3>{local[2][0], local[2][1], local[2][2]},
+        };
+
         bool valid_basis = true;
 
-        for (std::size_t column = 0; column < 3; ++column)
+        result.scale[0] = length(row[0]);
+        if (utils::nearly_equal(result.scale[0], zero))
         {
-            const Vector<T, 3> column_vector{
-                matrix[0][column],
-                matrix[1][column],
-                matrix[2][column],
-            };
+            valid_basis = false;
+            row[0] = Vector<T, 3>{one, zero, zero};
+        }
+        else
+        {
+            row[0] /= result.scale[0];
+        }
 
-            const T magnitude = length(column_vector);
-            result.scale[column] = magnitude;
+        // Compute shear XY and orthogonalise row 1 against row 0.
+        T shear_xy = dot(row[0], row[1]);
+        row[1] -= shear_xy * row[0];
 
-            if (utils::nearly_equal(magnitude, detail::zero<T>()))
-            {
-                valid_basis = false;
-                basis[column] = Vector<T, 3>{detail::zero<T>()};
-            }
-            else
-            {
-                basis[column] = column_vector / magnitude;
-            }
+        result.scale[1] = length(row[1]);
+        if (utils::nearly_equal(result.scale[1], zero))
+        {
+            valid_basis = false;
+            row[1] = Vector<T, 3>{zero, one, zero};
+        }
+        else
+        {
+            row[1] /= result.scale[1];
+        }
+
+        // Compute shear XZ and orthogonalise row 2 against row 0.
+        T shear_xz = dot(row[0], row[2]);
+        row[2] -= shear_xz * row[0];
+
+        // Compute shear YZ and orthogonalise row 2 against row 1.
+        T shear_yz = dot(row[1], row[2]);
+        row[2] -= shear_yz * row[1];
+
+        result.scale[2] = length(row[2]);
+        if (utils::nearly_equal(result.scale[2], zero))
+        {
+            valid_basis = false;
+            row[2] = Vector<T, 3>{zero, zero, one};
+        }
+        else
+        {
+            row[2] /= result.scale[2];
         }
 
         if (valid_basis)
         {
-            const Vector<T, 3> cross_product = cross(basis[0], basis[1]);
-            if (dot(cross_product, basis[2]) < detail::zero<T>())
+            const Vector<T, 3> pdum3 = cross(row[1], row[2]);
+            if (dot(row[0], pdum3) < zero)
             {
-                result.scale[2] = -result.scale[2];
-                basis[2] *= static_cast<T>(-1);
+                for (std::size_t i = 0; i < 3; ++i)
+                {
+                    result.scale[i] = -result.scale[i];
+                    row[i] = -row[i];
+                }
             }
 
             Matrix<T, 3, 3> rotation_matrix{};
-            for (std::size_t column = 0; column < 3; ++column)
+            for (std::size_t r = 0; r < 3; ++r)
             {
-                rotation_matrix[0][column] = basis[column][0];
-                rotation_matrix[1][column] = basis[column][1];
-                rotation_matrix[2][column] = basis[column][2];
+                rotation_matrix[r][0] = row[r][0];
+                rotation_matrix[r][1] = row[r][1];
+                rotation_matrix[r][2] = row[r][2];
             }
 
             result.rotation = normalize(utils::to_quaternion(rotation_matrix));


### PR DESCRIPTION
## Summary
- normalize affine matrices before extracting transform components
- robustly orthogonalize the upper 3x3 to recover scale, rotation, and handedness

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e399b11bf083208840e5899e967717