### PR TITLE
Add scene serialization support and tests

### DIFF
--- a/engine/scene/CMakeLists.txt
+++ b/engine/scene/CMakeLists.txt
@@ -3,6 +3,7 @@ set(target_name engine_scene)
 add_library(${target_name}
     src/api.cpp
     src/scene.cpp
+    serialization/serializer.cpp
     systems/hierarchy_system.cpp
     systems/registry.cpp
     systems/transform_system.cpp

--- a/engine/scene/components/hierarchy.hpp
+++ b/engine/scene/components/hierarchy.hpp
@@ -2,6 +2,10 @@
 
 #include <entt/entt.hpp>
 
+#include <istream>
+#include <ostream>
+#include <type_traits>
+
 namespace engine::scene::components
 {
     struct Hierarchy
@@ -21,4 +25,57 @@ namespace engine::scene::components
     {
         return hierarchy.first_child != entt::null;
     }
+
+    namespace serialization
+    {
+        struct HierarchyRecord
+        {
+            using entity_type = std::underlying_type_t<entt::entity>;
+
+            entity_type parent{static_cast<entity_type>(entt::null)};
+            entity_type first_child{static_cast<entity_type>(entt::null)};
+            entity_type next_sibling{static_cast<entity_type>(entt::null)};
+            entity_type previous_sibling{static_cast<entity_type>(entt::null)};
+
+            [[nodiscard]] static constexpr entity_type null_value() noexcept
+            {
+                return static_cast<entity_type>(entt::null);
+            }
+        };
+
+        inline void encode(std::ostream& output, const Hierarchy& hierarchy)
+        {
+            output << static_cast<HierarchyRecord::entity_type>(hierarchy.parent) << ' '
+                   << static_cast<HierarchyRecord::entity_type>(hierarchy.first_child) << ' '
+                   << static_cast<HierarchyRecord::entity_type>(hierarchy.next_sibling) << ' '
+                   << static_cast<HierarchyRecord::entity_type>(hierarchy.previous_sibling);
+        }
+
+        inline HierarchyRecord decode_hierarchy(std::istream& input)
+        {
+            HierarchyRecord record{};
+            input >> record.parent >> record.first_child >> record.next_sibling >> record.previous_sibling;
+            return record;
+        }
+
+        template <typename Resolver>
+        [[nodiscard]] inline Hierarchy instantiate(const HierarchyRecord& record, Resolver&& resolver)
+        {
+            const auto resolve = [&](HierarchyRecord::entity_type value) {
+                if (value == HierarchyRecord::null_value())
+                {
+                    return entt::null;
+                }
+
+                return resolver(value);
+            };
+
+            return Hierarchy{
+                resolve(record.parent),
+                resolve(record.first_child),
+                resolve(record.next_sibling),
+                resolve(record.previous_sibling),
+            };
+        }
+    } // namespace serialization
 } // namespace engine::scene::components

--- a/engine/scene/components/name.hpp
+++ b/engine/scene/components/name.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <iomanip>
+#include <istream>
+#include <ostream>
 #include <string>
 #include <string_view>
 
@@ -24,4 +27,19 @@ namespace engine::scene::components
     {
         return name == text;
     }
+
+    namespace serialization
+    {
+        inline void encode(std::ostream& output, const Name& name)
+        {
+            output << std::quoted(name.value);
+        }
+
+        inline Name decode_name(std::istream& input)
+        {
+            Name name{};
+            input >> std::quoted(name.value);
+            return name;
+        }
+    } // namespace serialization
 } // namespace engine::scene::components

--- a/engine/scene/components/transform.hpp
+++ b/engine/scene/components/transform.hpp
@@ -4,6 +4,11 @@
 
 #include <entt/entt.hpp>
 
+#include <iomanip>
+#include <istream>
+#include <limits>
+#include <ostream>
+
 namespace engine::scene::components
 {
     struct LocalTransform
@@ -24,4 +29,69 @@ namespace engine::scene::components
     {
         registry.emplace_or_replace<DirtyTransform>(entity);
     }
+
+    namespace serialization
+    {
+        namespace detail
+        {
+            inline void encode_transform(std::ostream& output, const engine::math::Transform<float>& transform)
+            {
+                const auto previous_precision = output.precision();
+                output << std::setprecision(std::numeric_limits<float>::max_digits10)
+                       << transform.scale[0] << ' '
+                       << transform.scale[1] << ' '
+                       << transform.scale[2] << ' '
+                       << transform.rotation.w << ' '
+                       << transform.rotation.x << ' '
+                       << transform.rotation.y << ' '
+                       << transform.rotation.z << ' '
+                       << transform.translation[0] << ' '
+                       << transform.translation[1] << ' '
+                       << transform.translation[2];
+                output.precision(previous_precision);
+            }
+
+            inline engine::math::Transform<float> decode_transform(std::istream& input)
+            {
+                engine::math::Transform<float> transform{};
+                input >> transform.scale[0] >> transform.scale[1] >> transform.scale[2]
+                      >> transform.rotation.w >> transform.rotation.x >> transform.rotation.y >> transform.rotation.z
+                      >> transform.translation[0] >> transform.translation[1] >> transform.translation[2];
+                return transform;
+            }
+        } // namespace detail
+
+        inline void encode(std::ostream& output, const LocalTransform& transform)
+        {
+            detail::encode_transform(output, transform.value);
+        }
+
+        inline LocalTransform decode_local(std::istream& input)
+        {
+            LocalTransform transform{};
+            transform.value = detail::decode_transform(input);
+            return transform;
+        }
+
+        inline void encode(std::ostream& output, const WorldTransform& transform)
+        {
+            detail::encode_transform(output, transform.value);
+        }
+
+        inline WorldTransform decode_world(std::istream& input)
+        {
+            WorldTransform transform{};
+            transform.value = detail::decode_transform(input);
+            return transform;
+        }
+
+        inline void encode(std::ostream&, const DirtyTransform&)
+        {
+        }
+
+        inline DirtyTransform decode_dirty(std::istream&)
+        {
+            return DirtyTransform{};
+        }
+    } // namespace serialization
 } // namespace engine::scene::components

--- a/engine/scene/include/engine/scene/scene.hpp
+++ b/engine/scene/include/engine/scene/scene.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <istream>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
-#include <ostream>
 
 #include <entt/entt.hpp>
 
@@ -91,6 +92,9 @@ namespace engine::scene
 
         template <typename... Components>
         [[nodiscard]] auto view() const;
+
+        void save(std::ostream& output) const;
+        void load(std::istream& input);
 
     private:
         registry_type registry_{};

--- a/engine/scene/serialization/serializer.cpp
+++ b/engine/scene/serialization/serializer.cpp
@@ -1,0 +1,237 @@
+#include "serializer.hpp"
+
+#include "components/hierarchy.hpp"
+#include "components/name.hpp"
+#include "components/transform.hpp"
+#include "engine/scene/scene.hpp"
+
+#include <algorithm>
+#include <iomanip>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::scene::serialization
+{
+    namespace
+    {
+        using entity_type = Scene::entity_type;
+        using underlying_type = std::underlying_type_t<entity_type>;
+
+        [[nodiscard]] std::vector<entity_type> collect_entities(const Scene& scene)
+        {
+            std::vector<entity_type> entities;
+            entities.reserve(scene.registry().alive_count());
+
+            auto& registry = const_cast<Scene::registry_type&>(scene.registry());
+            auto view = registry.view<>();
+            for (auto it = view.begin(); it != view.end(); ++it)
+            {
+                auto [entity] = *it;
+                entities.push_back(entity);
+            }
+
+            std::sort(entities.begin(), entities.end(), [](entity_type lhs, entity_type rhs) {
+                return static_cast<underlying_type>(lhs) < static_cast<underlying_type>(rhs);
+            });
+
+            return entities;
+        }
+    } // namespace
+
+    void save(const Scene& scene, std::ostream& output)
+    {
+        using components::serialization::encode;
+
+        const auto name = std::string{scene.name()};
+        output << "scene " << std::quoted(name) << ' ' << scene.registry().alive_count() << '\n';
+
+        const auto entities = collect_entities(scene);
+        const auto& registry = scene.registry();
+
+        for (const auto entity : entities)
+        {
+            std::size_t component_count = 0;
+            if (registry.any_of<components::Name>(entity)) ++component_count;
+            if (registry.any_of<components::Hierarchy>(entity)) ++component_count;
+            if (registry.any_of<components::LocalTransform>(entity)) ++component_count;
+            if (registry.any_of<components::WorldTransform>(entity)) ++component_count;
+            if (registry.any_of<components::DirtyTransform>(entity)) ++component_count;
+
+            output << "entity " << static_cast<underlying_type>(entity) << ' ' << component_count << '\n';
+
+            if (registry.any_of<components::Name>(entity))
+            {
+                output << "component Name ";
+                encode(output, registry.get<components::Name>(entity));
+                output << '\n';
+            }
+
+            if (registry.any_of<components::Hierarchy>(entity))
+            {
+                output << "component Hierarchy ";
+                encode(output, registry.get<components::Hierarchy>(entity));
+                output << '\n';
+            }
+
+            if (registry.any_of<components::LocalTransform>(entity))
+            {
+                output << "component LocalTransform ";
+                encode(output, registry.get<components::LocalTransform>(entity));
+                output << '\n';
+            }
+
+            if (registry.any_of<components::WorldTransform>(entity))
+            {
+                output << "component WorldTransform ";
+                encode(output, registry.get<components::WorldTransform>(entity));
+                output << '\n';
+            }
+
+            if (registry.any_of<components::DirtyTransform>(entity))
+            {
+                output << "component DirtyTransform ";
+                encode(output, registry.get<components::DirtyTransform>(entity));
+                output << '\n';
+            }
+
+            output << "entity_end\n";
+        }
+
+        output << "scene_end\n";
+    }
+
+    void load(Scene& scene, std::istream& input)
+    {
+        using components::serialization::decode_dirty;
+        using components::serialization::decode_hierarchy;
+        using components::serialization::decode_local;
+        using components::serialization::decode_name;
+        using components::serialization::decode_world;
+
+        std::string token;
+        if (!(input >> token) || token != "scene")
+        {
+            throw std::runtime_error{"Scene serialization: expected 'scene' token"};
+        }
+
+        std::string name;
+        if (!(input >> std::quoted(name)))
+        {
+            throw std::runtime_error{"Scene serialization: failed to read scene name"};
+        }
+
+        std::size_t entity_count = 0;
+        if (!(input >> entity_count))
+        {
+            throw std::runtime_error{"Scene serialization: failed to read entity count"};
+        }
+
+        scene.registry().clear();
+        scene.set_name(std::move(name));
+
+        struct PendingHierarchy
+        {
+            entity_type entity;
+            components::serialization::HierarchyRecord record;
+        };
+
+        std::vector<PendingHierarchy> pending;
+        pending.reserve(entity_count);
+        std::unordered_map<underlying_type, entity_type> id_map;
+        id_map.reserve(entity_count);
+
+        const auto expect_token = [&](std::string expected) {
+            std::string actual;
+            if (!(input >> actual) || actual != expected)
+            {
+                throw std::runtime_error{"Scene serialization: expected token '" + expected + "'"};
+            }
+        };
+
+        for (std::size_t i = 0; i < entity_count; ++i)
+        {
+            expect_token("entity");
+
+            underlying_type serialized_id{};
+            std::size_t component_count = 0;
+            if (!(input >> serialized_id >> component_count))
+            {
+                throw std::runtime_error{"Scene serialization: failed to read entity header"};
+            }
+
+            const auto entity = scene.registry().create();
+            id_map.emplace(serialized_id, entity);
+
+            for (std::size_t component_index = 0; component_index < component_count; ++component_index)
+            {
+                expect_token("component");
+
+                std::string component_type;
+                if (!(input >> component_type))
+                {
+                    throw std::runtime_error{"Scene serialization: failed to read component type"};
+                }
+
+                if (component_type == "Name")
+                {
+                    auto component = decode_name(input);
+                    scene.registry().emplace_or_replace<components::Name>(entity, std::move(component));
+                }
+                else if (component_type == "Hierarchy")
+                {
+                    auto record = decode_hierarchy(input);
+                    pending.push_back(PendingHierarchy{entity, record});
+                }
+                else if (component_type == "LocalTransform")
+                {
+                    auto component = decode_local(input);
+                    scene.registry().emplace_or_replace<components::LocalTransform>(entity, component);
+                }
+                else if (component_type == "WorldTransform")
+                {
+                    auto component = decode_world(input);
+                    scene.registry().emplace_or_replace<components::WorldTransform>(entity, component);
+                }
+                else if (component_type == "DirtyTransform")
+                {
+                    static_cast<void>(decode_dirty(input));
+                    scene.registry().emplace_or_replace<components::DirtyTransform>(entity);
+                }
+                else
+                {
+                    throw std::runtime_error{"Scene serialization: unknown component type '" + component_type + "'"};
+                }
+            }
+
+            expect_token("entity_end");
+        }
+
+        expect_token("scene_end");
+
+        for (const auto& pending_entry : pending)
+        {
+            const auto resolver = [&](components::serialization::HierarchyRecord::entity_type value) {
+                if (value == components::serialization::HierarchyRecord::null_value())
+                {
+                    return entt::null;
+                }
+
+                const auto it = id_map.find(value);
+                if (it == id_map.end())
+                {
+                    throw std::runtime_error{"Scene serialization: unresolved hierarchy reference"};
+                }
+
+                return it->second;
+            };
+
+            const auto hierarchy = components::serialization::instantiate(pending_entry.record, resolver);
+            scene.registry().emplace_or_replace<components::Hierarchy>(pending_entry.entity, hierarchy);
+        }
+    }
+} // namespace engine::scene::serialization

--- a/engine/scene/serialization/serializer.hpp
+++ b/engine/scene/serialization/serializer.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace engine::scene
+{
+    class Scene;
+}
+
+namespace engine::scene::serialization
+{
+    void save(const Scene& scene, std::ostream& output);
+    void load(Scene& scene, std::istream& input);
+}

--- a/engine/scene/src/scene.cpp
+++ b/engine/scene/src/scene.cpp
@@ -1,6 +1,7 @@
 #include "engine/scene/scene.hpp"
 #include "engine/scene/components.hpp"
 #include "engine/scene/systems.hpp"
+#include "serialization/serializer.hpp"
 
 #include <utility>
 
@@ -84,6 +85,16 @@ const Scene::registry_type& Scene::registry() const noexcept {
 void Scene::initialize_systems()
 {
     systems::register_scene_systems(registry_);
+}
+
+void Scene::save(std::ostream& output) const
+{
+    serialization::save(*this, output);
+}
+
+void Scene::load(std::istream& input)
+{
+    serialization::load(*this, input);
 }
 
 }  // namespace engine::scene

--- a/engine/scene/tests/CMakeLists.txt
+++ b/engine/scene/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(engine_scene_tests
     test_components.cpp
     test_module.cpp
     test_systems.cpp
+    test_serialization.cpp
 )
 
 set_target_properties(engine_scene_tests PROPERTIES

--- a/engine/scene/tests/test_serialization.cpp
+++ b/engine/scene/tests/test_serialization.cpp
@@ -1,0 +1,143 @@
+#include "engine/scene/components.hpp"
+#include "engine/scene/scene.hpp"
+
+#include "gtest/gtest.h"
+
+#include <array>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+namespace engine::scene::tests
+{
+    namespace
+    {
+        using engine::scene::components::Hierarchy;
+        using engine::scene::components::LocalTransform;
+        using engine::scene::components::Name;
+        using engine::scene::components::WorldTransform;
+        using engine::scene::components::DirtyTransform;
+
+        [[nodiscard]] engine::math::Transform<float> make_transform(const std::array<float, 3>& scale,
+                                                                    const std::array<float, 4>& rotation,
+                                                                    const std::array<float, 3>& translation)
+        {
+            engine::math::Transform<float> transform{};
+            transform.scale = engine::math::Vector<float, 3>{scale[0], scale[1], scale[2]};
+            transform.rotation = engine::math::Quaternion<float>{rotation[0], rotation[1], rotation[2], rotation[3]};
+            transform.translation = engine::math::Vector<float, 3>{translation[0], translation[1], translation[2]};
+            return transform;
+        }
+    } // namespace
+
+    TEST(SceneSerialization, RoundTripScene)
+    {
+        Scene original{"RoundTrip"};
+
+        auto root = original.create_entity();
+        auto child = original.create_entity();
+
+        root.emplace<Name>(Name{"Root"});
+        child.emplace<Name>(Name{"Child"});
+
+        Hierarchy root_hierarchy{};
+        root_hierarchy.parent = entt::null;
+        root_hierarchy.first_child = child.id();
+        root_hierarchy.next_sibling = entt::null;
+        root_hierarchy.previous_sibling = entt::null;
+        original.registry().emplace<Hierarchy>(root.id(), root_hierarchy);
+
+        Hierarchy child_hierarchy{};
+        child_hierarchy.parent = root.id();
+        child_hierarchy.first_child = entt::null;
+        child_hierarchy.next_sibling = entt::null;
+        child_hierarchy.previous_sibling = entt::null;
+        original.registry().emplace<Hierarchy>(child.id(), child_hierarchy);
+
+        LocalTransform root_local{};
+        root_local.value = make_transform({1.0f, 2.0f, 3.0f}, {1.0f, 0.0f, 0.5f, 0.75f}, {10.0f, 0.0f, -5.0f});
+        original.registry().emplace<LocalTransform>(root.id(), root_local);
+
+        WorldTransform root_world{};
+        root_world.value = make_transform({0.5f, 0.5f, 0.5f}, {0.0f, 1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
+        original.registry().emplace<WorldTransform>(root.id(), root_world);
+
+        original.registry().emplace<DirtyTransform>(root.id());
+
+        LocalTransform child_local{};
+        child_local.value = make_transform({0.25f, 0.75f, 1.25f}, {0.5f, 0.5f, 0.25f, 0.75f}, {2.0f, 3.0f, 4.0f});
+        original.registry().emplace<LocalTransform>(child.id(), child_local);
+
+        std::stringstream buffer;
+        original.save(buffer);
+
+        Scene restored{"placeholder"};
+        restored.load(buffer);
+
+        EXPECT_EQ(std::string(restored.name()), "RoundTrip");
+        EXPECT_EQ(restored.registry().alive_count(), 2u);
+
+        std::unordered_map<std::string, entt::entity> entities_by_name;
+        auto name_view = restored.registry().view<Name>();
+        for (auto it = name_view.begin(); it != name_view.end(); ++it)
+        {
+            auto [entity, name] = *it;
+            entities_by_name.emplace(name.value, entity);
+        }
+
+        ASSERT_EQ(entities_by_name.size(), 2u);
+        const auto root_entity = entities_by_name.at("Root");
+        const auto child_entity = entities_by_name.at("Child");
+
+        const auto& restored_root_hierarchy = restored.registry().get<Hierarchy>(root_entity);
+        EXPECT_EQ(restored_root_hierarchy.parent, entt::null);
+        EXPECT_EQ(restored_root_hierarchy.first_child, child_entity);
+        EXPECT_EQ(restored_root_hierarchy.next_sibling, entt::null);
+        EXPECT_EQ(restored_root_hierarchy.previous_sibling, entt::null);
+
+        const auto& restored_child_hierarchy = restored.registry().get<Hierarchy>(child_entity);
+        EXPECT_EQ(restored_child_hierarchy.parent, root_entity);
+        EXPECT_EQ(restored_child_hierarchy.first_child, entt::null);
+        EXPECT_EQ(restored_child_hierarchy.next_sibling, entt::null);
+        EXPECT_EQ(restored_child_hierarchy.previous_sibling, entt::null);
+
+        const auto& restored_root_local = restored.registry().get<LocalTransform>(root_entity);
+        EXPECT_FLOAT_EQ(restored_root_local.value.scale[0], root_local.value.scale[0]);
+        EXPECT_FLOAT_EQ(restored_root_local.value.scale[1], root_local.value.scale[1]);
+        EXPECT_FLOAT_EQ(restored_root_local.value.scale[2], root_local.value.scale[2]);
+        EXPECT_FLOAT_EQ(restored_root_local.value.rotation.w, root_local.value.rotation.w);
+        EXPECT_FLOAT_EQ(restored_root_local.value.rotation.x, root_local.value.rotation.x);
+        EXPECT_FLOAT_EQ(restored_root_local.value.rotation.y, root_local.value.rotation.y);
+        EXPECT_FLOAT_EQ(restored_root_local.value.rotation.z, root_local.value.rotation.z);
+        EXPECT_FLOAT_EQ(restored_root_local.value.translation[0], root_local.value.translation[0]);
+        EXPECT_FLOAT_EQ(restored_root_local.value.translation[1], root_local.value.translation[1]);
+        EXPECT_FLOAT_EQ(restored_root_local.value.translation[2], root_local.value.translation[2]);
+
+        const auto& restored_root_world = restored.registry().get<WorldTransform>(root_entity);
+        EXPECT_FLOAT_EQ(restored_root_world.value.scale[0], root_world.value.scale[0]);
+        EXPECT_FLOAT_EQ(restored_root_world.value.scale[1], root_world.value.scale[1]);
+        EXPECT_FLOAT_EQ(restored_root_world.value.scale[2], root_world.value.scale[2]);
+        EXPECT_FLOAT_EQ(restored_root_world.value.rotation.w, root_world.value.rotation.w);
+        EXPECT_FLOAT_EQ(restored_root_world.value.rotation.x, root_world.value.rotation.x);
+        EXPECT_FLOAT_EQ(restored_root_world.value.rotation.y, root_world.value.rotation.y);
+        EXPECT_FLOAT_EQ(restored_root_world.value.rotation.z, root_world.value.rotation.z);
+        EXPECT_FLOAT_EQ(restored_root_world.value.translation[0], root_world.value.translation[0]);
+        EXPECT_FLOAT_EQ(restored_root_world.value.translation[1], root_world.value.translation[1]);
+        EXPECT_FLOAT_EQ(restored_root_world.value.translation[2], root_world.value.translation[2]);
+
+        EXPECT_TRUE(restored.registry().any_of<DirtyTransform>(root_entity));
+        EXPECT_FALSE(restored.registry().any_of<DirtyTransform>(child_entity));
+
+        const auto& restored_child_local = restored.registry().get<LocalTransform>(child_entity);
+        EXPECT_FLOAT_EQ(restored_child_local.value.scale[0], child_local.value.scale[0]);
+        EXPECT_FLOAT_EQ(restored_child_local.value.scale[1], child_local.value.scale[1]);
+        EXPECT_FLOAT_EQ(restored_child_local.value.scale[2], child_local.value.scale[2]);
+        EXPECT_FLOAT_EQ(restored_child_local.value.rotation.w, child_local.value.rotation.w);
+        EXPECT_FLOAT_EQ(restored_child_local.value.rotation.x, child_local.value.rotation.x);
+        EXPECT_FLOAT_EQ(restored_child_local.value.rotation.y, child_local.value.rotation.y);
+        EXPECT_FLOAT_EQ(restored_child_local.value.rotation.z, child_local.value.rotation.z);
+        EXPECT_FLOAT_EQ(restored_child_local.value.translation[0], child_local.value.translation[0]);
+        EXPECT_FLOAT_EQ(restored_child_local.value.translation[1], child_local.value.translation[1]);
+        EXPECT_FLOAT_EQ(restored_child_local.value.translation[2], child_local.value.translation[2]);
+    }
+} // namespace engine::scene::tests


### PR DESCRIPTION
## Summary
- implement a text-based serializer for scenes, including persistence of name, hierarchy, and transform components
- expose Scene::save/load helpers and wire serialization into the build
- add a regression test that round-trips a multi-entity scene to verify fidelity

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68e4e06c2e8c8320a4d65337f14ff2b8