### PR TITLE
Implement platform windowing abstractions

### DIFF
--- a/engine/platform/CMakeLists.txt
+++ b/engine/platform/CMakeLists.txt
@@ -2,6 +2,11 @@ set(target_name engine_platform)
 
 add_library(${target_name}
     src/api.cpp
+    src/window_system.cpp
+    src/windowing/window_base.cpp
+    src/windowing/mock_window.cpp
+    src/windowing/glfw_window.cpp
+    src/windowing/sdl_window.cpp
 )
 
 target_include_directories(${target_name}
@@ -17,3 +22,4 @@ target_compile_definitions(${target_name}
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
+

--- a/engine/platform/include/engine/platform/window.hpp
+++ b/engine/platform/include/engine/platform/window.hpp
@@ -1,0 +1,235 @@
+#pragma once
+
+#include "engine/platform/api.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+namespace engine::platform {
+
+/// \brief Describes the windowing backend that should service a window instance.
+enum class WindowBackend {
+    /// Selects the most appropriate backend for the current platform. In this
+    /// reference implementation the selection prefers the mock backend to keep
+    /// CI headless friendly.
+    Auto,
+    /// Stub entry for a GLFW-driven implementation.
+    GLFW,
+    /// Stub entry for a SDL-driven implementation.
+    SDL,
+    /// Headless mock implementation used for tests and server environments.
+    Mock,
+};
+
+/// \brief Human readable configuration for constructing a window.
+struct WindowConfig {
+    /// Desired window title. Implementations copy this string during
+    /// construction.
+    std::string title{"Engine"};
+    /// Initial pixel width of the window client area.
+    std::uint32_t width{1280};
+    /// Initial pixel height of the window client area.
+    std::uint32_t height{720};
+    /// Whether the window should be initially visible.
+    bool visible{true};
+    /// Whether the window may be resized by the user.
+    bool resizable{true};
+};
+
+/// \brief Enumerates logical event types emitted by a window backend.
+enum class EventType {
+    /// No event. Used when polling fails to retrieve a value.
+    None,
+    /// The user requested the window to close (e.g., alt+F4 or pressing the
+    /// close button).
+    CloseRequested,
+    /// The window client area has been resized. Payload is ResizeEvent.
+    Resized,
+    /// The window focus has changed. Payload is FocusEvent.
+    FocusChanged,
+    /// Implementation specific custom payload. Payload is std::string.
+    Custom,
+};
+
+/// \brief Payload describing a resize event.
+struct ResizeEvent {
+    std::uint32_t width{0};
+    std::uint32_t height{0};
+};
+
+/// \brief Payload describing a focus change.
+struct FocusEvent {
+    bool focused{false};
+};
+
+/// \brief Represents a window level event.
+struct Event {
+    using Payload = std::variant<std::monostate, ResizeEvent, FocusEvent, std::string>;
+
+    EventType type{EventType::None};
+    Payload payload{};
+
+    /// Convenience helper constructing a close event.
+    static Event close_requested() noexcept {
+        return Event{EventType::CloseRequested, {}};
+    }
+
+    /// Convenience helper constructing a resize event.
+    static Event resized(std::uint32_t width, std::uint32_t height) noexcept {
+        return Event{EventType::Resized, ResizeEvent{width, height}};
+    }
+
+    /// Convenience helper constructing a focus event.
+    static Event focus_changed(bool focused) noexcept {
+        return Event{EventType::FocusChanged, FocusEvent{focused}};
+    }
+
+    /// Convenience helper constructing a custom payload event.
+    static Event custom(std::string message) {
+        return Event{EventType::Custom, std::move(message)};
+    }
+};
+
+/// \brief Interface describing a queue of window events.
+class EventQueue {
+public:
+    virtual ~EventQueue() noexcept = default;
+
+    /// Pushes a new event into the queue. Implementations own the event copy
+    /// and must remain valid until it is polled.
+    virtual void push(Event event) = 0;
+
+    /// Attempts to pop an event from the queue. Returns true when an event was
+    /// available and assigns it to \p out_event.
+    virtual bool poll(Event& out_event) = 0;
+
+    /// Removes all pending events from the queue.
+    virtual void clear() noexcept = 0;
+
+    /// Returns true when no events are waiting to be processed.
+    [[nodiscard]] virtual bool empty() const noexcept = 0;
+
+    /// Returns the number of queued events. Intended for diagnostics and
+    /// testing only.
+    [[nodiscard]] virtual std::size_t size() const noexcept = 0;
+};
+
+/// \brief Interface representing a swapchain ready surface.
+class SwapchainSurface {
+public:
+    virtual ~SwapchainSurface() noexcept = default;
+
+    /// Identifies the renderer backend that produced the surface (e.g.,
+    /// "vulkan", "d3d12").
+    [[nodiscard]] virtual std::string_view renderer_backend() const noexcept = 0;
+
+    /// Identifies the window backend used to create the surface. Helpful for
+    /// logging and validation.
+    [[nodiscard]] virtual std::string_view window_backend() const noexcept = 0;
+
+    /// Returns the opaque native surface handle. The meaning of this pointer is
+    /// backend specific.
+    [[nodiscard]] virtual void* native_surface() const noexcept = 0;
+
+    /// User supplied pointer forwarded when constructing the surface.
+    [[nodiscard]] virtual void* user_data() const noexcept = 0;
+};
+
+/// \brief Configuration forwarded to swapchain surface creation routines.
+struct SwapchainSurfaceRequest {
+    /// Renderer backend identifier (e.g., "vulkan").
+    std::string renderer_backend;
+
+    /// Optional hook invoked by the platform layer to hand control to the
+    /// rendering subsystem. The callback receives the request and the native
+    /// window handle. Returning nullptr signals that the hook could not create
+    /// the surface and that the platform layer should fall back to an internal
+    /// stub implementation.
+    using Hook = std::function<std::unique_ptr<SwapchainSurface>(
+        const SwapchainSurfaceRequest&, void* native_window_handle)>;
+
+    Hook hook{};
+
+    /// Optional opaque pointer forwarded to the renderer. The platform layer
+    /// stores it inside the fallback surface implementation when provided.
+    void* user_data{nullptr};
+};
+
+/// \brief Abstract window interface exposed by the platform module.
+class Window {
+public:
+    virtual ~Window() noexcept = default;
+
+    /// Identifies the active backend responsible for this window.
+    [[nodiscard]] virtual std::string_view backend_name() const noexcept = 0;
+
+    /// Returns the configuration snapshot captured when the window was
+    /// constructed.
+    [[nodiscard]] virtual const WindowConfig& config() const noexcept = 0;
+
+    /// Makes the window visible.
+    virtual void show() = 0;
+
+    /// Hides the window.
+    virtual void hide() = 0;
+
+    /// Reports the last visibility state requested by the application.
+    [[nodiscard]] virtual bool is_visible() const noexcept = 0;
+
+    /// Requests the window to close. Implementations enqueue a corresponding
+    /// CloseRequested event.
+    virtual void request_close() = 0;
+
+    /// Reports whether the window received a close request. This flag is
+    /// cleared automatically when a new frame of events is pumped.
+    [[nodiscard]] virtual bool close_requested() const noexcept = 0;
+
+    /// Allows synthetic events to be posted into the backend event stream.
+    /// Real implementations typically call this from their OS callbacks while
+    /// tests may use it to emulate native behaviour. Events posted here are
+    /// expected to materialise after the next call to pump_events().
+    virtual void post_event(Event event) = 0;
+
+    /// Pumps pending backend events, forwarding them into the shared event
+    /// queue. Implementations are responsible for translating native events
+    /// into the abstract Event type.
+    virtual void pump_events() = 0;
+
+    /// Accessor to the shared event queue. Ownership remains with the window
+    /// and is released automatically when the window is destroyed.
+    [[nodiscard]] virtual EventQueue& event_queue() noexcept = 0;
+
+    /// Const overload of event_queue().
+    [[nodiscard]] virtual const EventQueue& event_queue() const noexcept = 0;
+
+    /// Creates or acquires a swapchain surface for the given renderer backend.
+    /// Implementations invoke the optional hook before falling back to an
+    /// internal stub surface. The caller assumes ownership of the returned
+    /// object and must destroy it before destroying the window.
+    [[nodiscard]] virtual std::unique_ptr<SwapchainSurface> create_swapchain_surface(
+        const SwapchainSurfaceRequest& request) = 0;
+};
+
+/// \brief Allocates an in-memory event queue. The caller assumes shared
+/// ownership using std::shared_ptr semantics. Destroying the last reference
+/// releases the underlying storage.
+[[nodiscard]] ENGINE_PLATFORM_API std::shared_ptr<EventQueue> create_event_queue();
+
+/// \brief Constructs a window using the requested backend and event queue.
+/// The returned pointer follows shared ownership semantics. Destroying the
+/// last reference releases the native resources held by the window as well as
+/// the associated event queue. When \p backend is WindowBackend::Auto the
+/// implementation selects the most suitable backend for the current build.
+[[nodiscard]] ENGINE_PLATFORM_API std::shared_ptr<Window> create_window(
+    WindowConfig config,
+    WindowBackend backend = WindowBackend::Auto,
+    std::shared_ptr<EventQueue> event_queue = {});
+
+}  // namespace engine::platform
+

--- a/engine/platform/src/window_system.cpp
+++ b/engine/platform/src/window_system.cpp
@@ -1,0 +1,105 @@
+#include "engine/platform/window.hpp"
+
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::platform {
+
+namespace windowing {
+std::shared_ptr<Window> create_mock_window(WindowConfig config,
+                                           std::shared_ptr<EventQueue> queue);
+std::shared_ptr<Window> create_glfw_window(WindowConfig config,
+                                           std::shared_ptr<EventQueue> queue);
+std::shared_ptr<Window> create_sdl_window(WindowConfig config,
+                                          std::shared_ptr<EventQueue> queue);
+}  // namespace windowing
+
+namespace {
+
+class LocalEventQueue final : public EventQueue {
+public:
+    void push(Event event) override {
+        std::scoped_lock lock{mutex_};
+        queue_.push_back(std::move(event));
+    }
+
+    bool poll(Event& out_event) override {
+        std::scoped_lock lock{mutex_};
+        if (queue_.empty()) {
+            return false;
+        }
+
+        out_event = std::move(queue_.front());
+        queue_.pop_front();
+        return true;
+    }
+
+    void clear() noexcept override {
+        std::scoped_lock lock{mutex_};
+        queue_.clear();
+    }
+
+    [[nodiscard]] bool empty() const noexcept override {
+        std::scoped_lock lock{mutex_};
+        return queue_.empty();
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept override {
+        std::scoped_lock lock{mutex_};
+        return queue_.size();
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::deque<Event> queue_;
+};
+
+std::shared_ptr<EventQueue> ensure_queue(std::shared_ptr<EventQueue> queue) {
+    if (!queue) {
+        return std::make_shared<LocalEventQueue>();
+    }
+    return queue;
+}
+
+std::shared_ptr<Window> create_window_with_backend(WindowConfig config,
+                                                   WindowBackend backend,
+                                                   std::shared_ptr<EventQueue> queue) {
+    using windowing::create_glfw_window;
+    using windowing::create_mock_window;
+    using windowing::create_sdl_window;
+
+    switch (backend) {
+        case WindowBackend::Auto:
+        case WindowBackend::Mock:
+            return create_mock_window(std::move(config), std::move(queue));
+        case WindowBackend::GLFW:
+            return create_glfw_window(std::move(config), std::move(queue));
+        case WindowBackend::SDL:
+            return create_sdl_window(std::move(config), std::move(queue));
+    }
+
+    throw std::runtime_error{"Unsupported window backend"};
+}
+
+}  // namespace
+
+std::shared_ptr<EventQueue> create_event_queue() {
+    return std::make_shared<LocalEventQueue>();
+}
+
+std::shared_ptr<Window> create_window(WindowConfig config,
+                                      WindowBackend backend,
+                                      std::shared_ptr<EventQueue> event_queue) {
+    auto queue = ensure_queue(std::move(event_queue));
+    if (backend == WindowBackend::Auto) {
+        backend = WindowBackend::Mock;
+    }
+
+    return create_window_with_backend(std::move(config), backend, std::move(queue));
+}
+
+}  // namespace engine::platform
+

--- a/engine/platform/src/windowing/glfw_window.cpp
+++ b/engine/platform/src/windowing/glfw_window.cpp
@@ -1,0 +1,13 @@
+#include "window_base.hpp"
+
+#include <utility>
+
+namespace engine::platform::windowing {
+
+std::shared_ptr<Window> create_glfw_window(WindowConfig config,
+                                           std::shared_ptr<EventQueue> queue) {
+    return create_headless_window("glfw-stub", std::move(config), std::move(queue));
+}
+
+}  // namespace engine::platform::windowing
+

--- a/engine/platform/src/windowing/mock_window.cpp
+++ b/engine/platform/src/windowing/mock_window.cpp
@@ -1,0 +1,13 @@
+#include "window_base.hpp"
+
+#include <utility>
+
+namespace engine::platform::windowing {
+
+std::shared_ptr<Window> create_mock_window(WindowConfig config,
+                                           std::shared_ptr<EventQueue> queue) {
+    return create_headless_window("mock", std::move(config), std::move(queue));
+}
+
+}  // namespace engine::platform::windowing
+

--- a/engine/platform/src/windowing/sdl_window.cpp
+++ b/engine/platform/src/windowing/sdl_window.cpp
@@ -1,0 +1,13 @@
+#include "window_base.hpp"
+
+#include <utility>
+
+namespace engine::platform::windowing {
+
+std::shared_ptr<Window> create_sdl_window(WindowConfig config,
+                                          std::shared_ptr<EventQueue> queue) {
+    return create_headless_window("sdl-stub", std::move(config), std::move(queue));
+}
+
+}  // namespace engine::platform::windowing
+

--- a/engine/platform/src/windowing/window_base.cpp
+++ b/engine/platform/src/windowing/window_base.cpp
@@ -1,0 +1,137 @@
+#include "window_base.hpp"
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::platform::windowing {
+
+HeadlessSwapchainSurface::HeadlessSwapchainSurface(std::string renderer_backend,
+                                                   std::string window_backend,
+                                                   void* native_surface,
+                                                   void* user_data) noexcept
+    : renderer_backend_(std::move(renderer_backend)),
+      window_backend_(std::move(window_backend)),
+      native_surface_(native_surface),
+      user_data_(user_data) {}
+
+std::string_view HeadlessSwapchainSurface::renderer_backend() const noexcept {
+    return renderer_backend_;
+}
+
+std::string_view HeadlessSwapchainSurface::window_backend() const noexcept {
+    return window_backend_;
+}
+
+void* HeadlessSwapchainSurface::native_surface() const noexcept {
+    return native_surface_;
+}
+
+void* HeadlessSwapchainSurface::user_data() const noexcept {
+    return user_data_;
+}
+
+HeadlessWindow::HeadlessWindow(std::string backend_name,
+                               WindowConfig config,
+                               std::shared_ptr<EventQueue> queue)
+    : backend_name_(std::move(backend_name)),
+      config_(std::move(config)),
+      visible_(config_.visible),
+      close_requested_(false),
+      queue_(std::move(queue)) {
+    if (!queue_) {
+        throw std::invalid_argument{"Event queue must not be null"};
+    }
+}
+
+HeadlessWindow::~HeadlessWindow() noexcept = default;
+
+std::string_view HeadlessWindow::backend_name() const noexcept {
+    return backend_name_;
+}
+
+const WindowConfig& HeadlessWindow::config() const noexcept {
+    return config_;
+}
+
+void HeadlessWindow::show() {
+    visible_ = true;
+}
+
+void HeadlessWindow::hide() {
+    visible_ = false;
+}
+
+bool HeadlessWindow::is_visible() const noexcept {
+    return visible_;
+}
+
+void HeadlessWindow::request_close() {
+    close_requested_ = true;
+    post_event(Event::close_requested());
+}
+
+bool HeadlessWindow::close_requested() const noexcept {
+    return close_requested_;
+}
+
+void HeadlessWindow::post_event(Event event) {
+    std::scoped_lock lock{mutex_};
+    pending_events_.push_back(std::move(event));
+}
+
+void HeadlessWindow::pump_events() {
+    flush_pending_events();
+    close_requested_ = false;
+}
+
+EventQueue& HeadlessWindow::event_queue() noexcept {
+    return *queue_;
+}
+
+const EventQueue& HeadlessWindow::event_queue() const noexcept {
+    return *queue_;
+}
+
+std::unique_ptr<SwapchainSurface> HeadlessWindow::create_swapchain_surface(
+    const SwapchainSurfaceRequest& request) {
+    if (request.hook) {
+        if (auto surface = request.hook(request, native_handle())) {
+            return surface;
+        }
+    }
+
+    return std::make_unique<HeadlessSwapchainSurface>(
+        request.renderer_backend,
+        std::string{backend_name_},
+        native_handle(),
+        request.user_data);
+}
+
+void* HeadlessWindow::native_handle() noexcept {
+    return this;
+}
+
+void HeadlessWindow::flush_pending_events() {
+    std::deque<Event> local;
+    {
+        std::scoped_lock lock{mutex_};
+        local.swap(pending_events_);
+    }
+
+    for (auto& event : local) {
+        queue_->push(std::move(event));
+    }
+}
+
+std::shared_ptr<Window> create_headless_window(std::string backend_name,
+                                               WindowConfig config,
+                                               std::shared_ptr<EventQueue> queue) {
+    return std::make_shared<HeadlessWindow>(
+        std::move(backend_name),
+        std::move(config),
+        std::move(queue));
+}
+
+}  // namespace engine::platform::windowing
+

--- a/engine/platform/src/windowing/window_base.hpp
+++ b/engine/platform/src/windowing/window_base.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "engine/platform/window.hpp"
+
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace engine::platform::windowing {
+
+class HeadlessSwapchainSurface final : public SwapchainSurface {
+public:
+    HeadlessSwapchainSurface(std::string renderer_backend,
+                             std::string window_backend,
+                             void* native_surface,
+                             void* user_data) noexcept;
+
+    [[nodiscard]] std::string_view renderer_backend() const noexcept override;
+    [[nodiscard]] std::string_view window_backend() const noexcept override;
+    [[nodiscard]] void* native_surface() const noexcept override;
+    [[nodiscard]] void* user_data() const noexcept override;
+
+private:
+    std::string renderer_backend_;
+    std::string window_backend_;
+    void* native_surface_;
+    void* user_data_;
+};
+
+class HeadlessWindow : public Window {
+public:
+    HeadlessWindow(std::string backend_name,
+                   WindowConfig config,
+                   std::shared_ptr<EventQueue> queue);
+    ~HeadlessWindow() noexcept override;
+
+    [[nodiscard]] std::string_view backend_name() const noexcept override;
+    [[nodiscard]] const WindowConfig& config() const noexcept override;
+    void show() override;
+    void hide() override;
+    [[nodiscard]] bool is_visible() const noexcept override;
+    void request_close() override;
+    [[nodiscard]] bool close_requested() const noexcept override;
+    void post_event(Event event) override;
+    void pump_events() override;
+    [[nodiscard]] EventQueue& event_queue() noexcept override;
+    [[nodiscard]] const EventQueue& event_queue() const noexcept override;
+    [[nodiscard]] std::unique_ptr<SwapchainSurface> create_swapchain_surface(
+        const SwapchainSurfaceRequest& request) override;
+
+protected:
+    [[nodiscard]] void* native_handle() noexcept;
+
+private:
+    void flush_pending_events();
+
+    std::string backend_name_;
+    WindowConfig config_;
+    bool visible_;
+    bool close_requested_;
+    std::shared_ptr<EventQueue> queue_;
+    std::deque<Event> pending_events_;
+    std::mutex mutex_;
+};
+
+std::shared_ptr<Window> create_headless_window(std::string backend_name,
+                                               WindowConfig config,
+                                               std::shared_ptr<EventQueue> queue);
+
+}  // namespace engine::platform::windowing
+

--- a/engine/platform/tests/test_module.cpp
+++ b/engine/platform/tests/test_module.cpp
@@ -1,8 +1,164 @@
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <string>
+#include <variant>
+
 #include "engine/platform/api.hpp"
+#include "engine/platform/window.hpp"
+
+namespace {
+
+class HookedSurface final : public engine::platform::SwapchainSurface {
+public:
+    HookedSurface(std::string renderer_backend,
+                  std::string window_backend,
+                  void* native_surface,
+                  void* user_data)
+        : renderer_backend_(std::move(renderer_backend)),
+          window_backend_(std::move(window_backend)),
+          native_surface_(native_surface),
+          user_data_(user_data) {}
+
+    [[nodiscard]] std::string_view renderer_backend() const noexcept override {
+        return renderer_backend_;
+    }
+
+    [[nodiscard]] std::string_view window_backend() const noexcept override {
+        return window_backend_;
+    }
+
+    [[nodiscard]] void* native_surface() const noexcept override {
+        return native_surface_;
+    }
+
+    [[nodiscard]] void* user_data() const noexcept override {
+        return user_data_;
+    }
+
+private:
+    std::string renderer_backend_;
+    std::string window_backend_;
+    void* native_surface_;
+    void* user_data_;
+};
+
+}  // namespace
 
 TEST(PlatformModule, ModuleNameMatchesNamespace) {
     EXPECT_EQ(engine::platform::module_name(), "platform");
     EXPECT_STREQ(engine_platform_module_name(), "platform");
 }
+
+TEST(PlatformWindowing, MockWindowLifecycle) {
+    using namespace engine::platform;
+
+    WindowConfig config;
+    config.title = "Unit Test";
+    config.visible = false;
+
+    auto window = create_window(config, WindowBackend::Mock);
+    ASSERT_TRUE(window != nullptr);
+    EXPECT_EQ(window->backend_name(), "mock");
+    EXPECT_FALSE(window->is_visible());
+
+    window->show();
+    EXPECT_TRUE(window->is_visible());
+    window->hide();
+    EXPECT_FALSE(window->is_visible());
+
+    EXPECT_FALSE(window->close_requested());
+    window->request_close();
+    EXPECT_TRUE(window->close_requested());
+
+    window->pump_events();
+    EXPECT_FALSE(window->close_requested());
+
+    Event event;
+    ASSERT_TRUE(window->event_queue().poll(event));
+    EXPECT_TRUE(event.type == EventType::CloseRequested);
+    EXPECT_TRUE(window->event_queue().empty());
+}
+
+TEST(PlatformWindowing, EventDispatchFlow) {
+    using namespace engine::platform;
+
+    auto window = create_window(WindowConfig{}, WindowBackend::Mock);
+    ASSERT_TRUE(window != nullptr);
+
+    window->post_event(Event::custom("payload"));
+    window->post_event(Event::resized(640, 480));
+    window->post_event(Event::focus_changed(true));
+
+    window->pump_events();
+
+    Event event;
+    ASSERT_TRUE(window->event_queue().poll(event));
+    EXPECT_TRUE(event.type == EventType::Custom);
+    EXPECT_EQ(std::get<std::string>(event.payload), "payload");
+
+    ASSERT_TRUE(window->event_queue().poll(event));
+    EXPECT_TRUE(event.type == EventType::Resized);
+    auto resize = std::get<ResizeEvent>(event.payload);
+    EXPECT_EQ(resize.width, 640u);
+    EXPECT_EQ(resize.height, 480u);
+
+    ASSERT_TRUE(window->event_queue().poll(event));
+    EXPECT_TRUE(event.type == EventType::FocusChanged);
+    auto focus = std::get<FocusEvent>(event.payload);
+    EXPECT_TRUE(focus.focused);
+
+    EXPECT_FALSE(window->event_queue().poll(event));
+}
+
+TEST(PlatformWindowing, SwapchainHookIsInvoked) {
+    using namespace engine::platform;
+
+    auto window = create_window(WindowConfig{}, WindowBackend::Mock);
+    ASSERT_TRUE(window != nullptr);
+
+    bool hook_called = false;
+    void* hook_native = nullptr;
+
+    SwapchainSurfaceRequest request{};
+    request.renderer_backend = "test-renderer";
+    request.user_data = reinterpret_cast<void*>(0x1234);
+    request.hook = [&](const SwapchainSurfaceRequest& req, void* native_handle) {
+        hook_called = true;
+        hook_native = native_handle;
+        return std::make_unique<HookedSurface>(
+            std::string{req.renderer_backend},
+            std::string{window->backend_name()},
+            native_handle,
+            req.user_data);
+    };
+
+    auto surface = window->create_swapchain_surface(request);
+    ASSERT_TRUE(hook_called);
+    ASSERT_TRUE(surface != nullptr);
+    EXPECT_EQ(surface->renderer_backend(), "test-renderer");
+    EXPECT_EQ(surface->window_backend(), window->backend_name());
+    EXPECT_EQ(surface->native_surface(), hook_native);
+    EXPECT_EQ(surface->user_data(), request.user_data);
+}
+
+TEST(PlatformWindowing, SwapchainFallbackWhenHookFails) {
+    using namespace engine::platform;
+
+    auto window = create_window(WindowConfig{}, WindowBackend::Mock);
+    ASSERT_TRUE(window != nullptr);
+
+    SwapchainSurfaceRequest request{};
+    request.renderer_backend = "fallback";
+    request.hook = [](const SwapchainSurfaceRequest&, void*) -> std::unique_ptr<SwapchainSurface> {
+        return nullptr;
+    };
+
+    auto surface = window->create_swapchain_surface(request);
+    ASSERT_TRUE(surface != nullptr);
+    EXPECT_EQ(surface->renderer_backend(), "fallback");
+    EXPECT_EQ(surface->window_backend(), window->backend_name());
+    EXPECT_TRUE(surface->native_surface() != nullptr);
+    EXPECT_EQ(surface->user_data(), request.user_data);
+}
+


### PR DESCRIPTION
## Summary
- add platform window/event/swapchain interfaces to the public headers
- implement headless window backends with GLFW/SDL scaffolding and shared event queue utilities
- extend platform unit tests with mock window lifecycle, event dispatch, and swapchain hook coverage

## Testing
- cmake --build build
- ctest

------
https://chatgpt.com/codex/tasks/task_e_68e4ea43f0788320a72cc44bbdfb7f96