### PR TITLE
Implement frame graph and forward rendering pipeline

### DIFF
--- a/engine/rendering/CMakeLists.txt
+++ b/engine/rendering/CMakeLists.txt
@@ -2,12 +2,16 @@ set(target_name engine_rendering)
 
 add_library(${target_name}
     src/api.cpp
+    src/frame_graph.cpp
+    src/forward_pipeline.cpp
+    src/material_system.cpp
 )
 
 target_include_directories(${target_name}
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
+        ${CMAKE_SOURCE_DIR}
+    )
 
 target_compile_definitions(${target_name}
     PRIVATE
@@ -18,7 +22,9 @@ target_compile_definitions(${target_name}
 target_link_libraries(${target_name}
     PUBLIC
         engine_core
+        engine_assets
         engine_platform
+        engine_scene
 )
 
 if(BUILD_TESTING)

--- a/engine/rendering/include/engine/rendering/README.md
+++ b/engine/rendering/include/engine/rendering/README.md
@@ -10,3 +10,8 @@ _Last updated: 2025-10-05_
 ### Files
 
 - `api.hpp` – C++ header.
+- `components.hpp` – Rendering-specific scene component definitions.
+- `frame_graph.hpp` – Frame graph interfaces.
+- `forward_pipeline.hpp` – Forward rendering pipeline interface.
+- `material_system.hpp` – Material management interfaces.
+- `render_pass.hpp` – Render pass abstractions.

--- a/engine/rendering/include/engine/rendering/components.hpp
+++ b/engine/rendering/include/engine/rendering/components.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "engine/assets/handles.hpp"
+
+namespace engine::rendering::components
+{
+    /**
+     * \brief Geometry component consumed by the rendering pipeline.
+     *
+     * Entities that should be rendered attach this component together with the
+     * transform components supplied by `engine::scene`.  The renderer will look
+     * for a `WorldTransform` on the same entity in order to obtain the final
+     * object-to-world matrix.
+     */
+    struct RenderGeometry
+    {
+        /// Handle of the mesh asset containing vertex and index buffers.
+        engine::assets::MeshHandle mesh{};
+
+        /// Handle of the material definition to bind when the mesh is drawn.
+        engine::assets::MaterialHandle material{};
+    };
+} // namespace engine::rendering::components

--- a/engine/rendering/include/engine/rendering/forward_pipeline.hpp
+++ b/engine/rendering/include/engine/rendering/forward_pipeline.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "engine/rendering/frame_graph.hpp"
+#include "engine/rendering/material_system.hpp"
+
+namespace engine::rendering
+{
+    /**
+     * \brief Minimal forward rendering pipeline that extracts draw calls from a scene.
+     */
+    class ForwardPipeline
+    {
+    public:
+        void render(scene::Scene& scene, RenderResourceProvider& resources, MaterialSystem& materials,
+                    FrameGraph& graph);
+    };
+}

--- a/engine/rendering/include/engine/rendering/frame_graph.hpp
+++ b/engine/rendering/include/engine/rendering/frame_graph.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <ostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "engine/rendering/render_pass.hpp"
+
+namespace engine::rendering
+{
+    class FrameGraph;
+
+    /// Handle identifying resources declared inside the frame-graph.
+    struct FrameGraphResourceHandle
+    {
+        std::size_t index{std::numeric_limits<std::size_t>::max()};
+
+        [[nodiscard]] bool valid() const noexcept
+        {
+            return index != std::numeric_limits<std::size_t>::max();
+        }
+
+        friend bool operator==(FrameGraphResourceHandle lhs, FrameGraphResourceHandle rhs) noexcept
+        {
+            return lhs.index == rhs.index;
+        }
+    };
+
+    /// Lifetime category of a frame-graph resource.
+    enum class ResourceLifetime
+    {
+        External,
+        Transient,
+    };
+
+    /// Immutable descriptor exposed to passes when querying resource metadata.
+    struct FrameGraphResourceInfo
+    {
+        std::string_view name;
+        ResourceLifetime lifetime{ResourceLifetime::Transient};
+    };
+
+    class FrameGraphPassBuilder
+    {
+    public:
+        FrameGraphPassBuilder(FrameGraph& graph, std::size_t pass_index);
+
+        FrameGraphResourceHandle read(FrameGraphResourceHandle handle);
+        FrameGraphResourceHandle write(FrameGraphResourceHandle handle);
+
+    private:
+        FrameGraph& graph_;
+        std::size_t pass_index_;
+    };
+
+    struct FrameGraphPassExecutionContext
+    {
+        RenderExecutionContext& render;
+        FrameGraph& graph;
+        std::size_t pass_index{std::numeric_limits<std::size_t>::max()};
+
+        [[nodiscard]] std::string_view pass_name() const;
+        [[nodiscard]] std::span<const FrameGraphResourceHandle> reads() const;
+        [[nodiscard]] std::span<const FrameGraphResourceHandle> writes() const;
+        [[nodiscard]] FrameGraphResourceInfo describe(FrameGraphResourceHandle handle) const;
+    };
+
+    /// Event emitted whenever the lifetime of a transient resource changes.
+    struct ResourceEvent
+    {
+        enum class Type
+        {
+            Acquire,
+            Release,
+        };
+
+        Type type{Type::Acquire};
+        std::string resource_name;
+        std::string pass_name;
+    };
+
+    inline std::ostream& operator<<(std::ostream& os, ResourceEvent::Type type)
+    {
+        switch (type)
+        {
+        case ResourceEvent::Type::Acquire:
+            return os << "Acquire";
+        case ResourceEvent::Type::Release:
+            return os << "Release";
+        }
+        return os;
+    }
+
+    /// Frame-graph implementation responsible for scheduling and execution.
+    class FrameGraph
+    {
+    public:
+        FrameGraph();
+
+        void reset();
+
+        FrameGraphResourceHandle create_resource(std::string name, ResourceLifetime lifetime = ResourceLifetime::Transient);
+
+        std::size_t add_pass(std::unique_ptr<RenderPass> pass);
+
+        void compile();
+        void execute(RenderExecutionContext& context);
+
+        [[nodiscard]] const std::vector<std::size_t>& execution_order() const noexcept;
+        [[nodiscard]] const std::vector<ResourceEvent>& resource_events() const noexcept;
+        [[nodiscard]] FrameGraphResourceInfo resource_info(FrameGraphResourceHandle handle) const;
+        [[nodiscard]] std::span<const FrameGraphResourceHandle> pass_reads(std::size_t pass_index);
+        [[nodiscard]] std::span<const FrameGraphResourceHandle> pass_writes(std::size_t pass_index);
+        [[nodiscard]] std::string_view pass_name(std::size_t pass_index) const;
+
+    private:
+        struct ResourceNode
+        {
+            std::string name;
+            ResourceLifetime lifetime{ResourceLifetime::Transient};
+            std::size_t writer{std::numeric_limits<std::size_t>::max()};
+            std::vector<std::size_t> readers;
+            std::size_t first_use{std::numeric_limits<std::size_t>::max()};
+            std::size_t last_use{std::numeric_limits<std::size_t>::max()};
+        };
+
+        struct PassNode
+        {
+            std::unique_ptr<RenderPass> pass;
+            std::vector<FrameGraphResourceHandle> reads;
+            std::vector<FrameGraphResourceHandle> writes;
+        };
+
+        std::vector<ResourceNode> resources_;
+        std::vector<PassNode> passes_;
+        std::vector<std::size_t> execution_order_;
+        std::vector<ResourceEvent> resource_events_;
+        bool compiled_{false};
+
+        friend class FrameGraphPassBuilder;
+        friend struct FrameGraphPassExecutionContext;
+    };
+}

--- a/engine/rendering/include/engine/rendering/material_system.hpp
+++ b/engine/rendering/include/engine/rendering/material_system.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <optional>
+#include <unordered_map>
+
+#include "engine/assets/handles.hpp"
+#include "engine/rendering/render_pass.hpp"
+
+namespace engine::rendering
+{
+    /**
+     * \brief Records material metadata and orchestrates GPU residency.
+     */
+    class MaterialSystem
+    {
+    public:
+        struct MaterialRecord
+        {
+            engine::assets::MaterialHandle material;
+            engine::assets::ShaderHandle shader;
+        };
+
+        void register_material(MaterialRecord record);
+
+        [[nodiscard]] bool has_material(const engine::assets::MaterialHandle& handle) const noexcept;
+
+        [[nodiscard]] std::optional<MaterialRecord> find(const engine::assets::MaterialHandle& handle) const;
+
+        void ensure_material_loaded(const engine::assets::MaterialHandle& handle, RenderResourceProvider& provider);
+
+        void clear() noexcept;
+
+    private:
+        std::unordered_map<engine::assets::MaterialHandle, MaterialRecord> materials_{};
+    };
+}

--- a/engine/rendering/include/engine/rendering/render_pass.hpp
+++ b/engine/rendering/include/engine/rendering/render_pass.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "engine/assets/handles.hpp"
+#include "engine/rendering/api.hpp"
+
+namespace engine::scene
+{
+    class Scene;
+}
+
+namespace engine::rendering
+{
+    class FrameGraphPassBuilder;
+    struct FrameGraphPassExecutionContext;
+    class MaterialSystem;
+
+    /**
+     * \brief Interface exposed by the platform layer to satisfy GPU resource requests.
+     */
+    class RenderResourceProvider
+    {
+    public:
+        virtual ~RenderResourceProvider() = default;
+
+        /// Ensure that the mesh identified by \p handle is resident on the GPU.
+        virtual void require_mesh(const engine::assets::MeshHandle& handle) = 0;
+
+        /// Ensure that the material identified by \p handle is ready for use.
+        virtual void require_material(const engine::assets::MaterialHandle& handle) = 0;
+
+        /// Ensure that the shader program identified by \p handle is compiled and boundable.
+        virtual void require_shader(const engine::assets::ShaderHandle& handle) = 0;
+    };
+
+    /**
+     * \brief Lightweight description of the scene subset to be rendered.
+     */
+    struct RenderView
+    {
+        scene::Scene& scene;
+    };
+
+    /**
+     * \brief Context passed to render passes during execution.
+     */
+    struct RenderExecutionContext
+    {
+        RenderResourceProvider& resources;
+        MaterialSystem& materials;
+        RenderView view;
+    };
+
+    /**
+     * \brief Abstract base class implemented by all render passes.
+     */
+    class RenderPass
+    {
+    public:
+        explicit RenderPass(std::string name);
+        virtual ~RenderPass() = default;
+
+        [[nodiscard]] std::string_view name() const noexcept;
+
+        /// Describe the resources that this pass will access.
+        virtual void setup(FrameGraphPassBuilder& builder) = 0;
+
+        /// Execute the pass using the inputs prepared by the frame-graph.
+        virtual void execute(FrameGraphPassExecutionContext& context) = 0;
+
+    private:
+        std::string name_;
+    };
+
+    /**
+     * \brief Convenience render pass that accepts lambdas for setup and execute.
+     */
+    class CallbackRenderPass final : public RenderPass
+    {
+    public:
+        using SetupFunction = std::function<void(FrameGraphPassBuilder&)>;
+        using ExecuteFunction = std::function<void(FrameGraphPassExecutionContext&)>;
+
+        CallbackRenderPass(std::string name, SetupFunction setup, ExecuteFunction execute);
+
+        void setup(FrameGraphPassBuilder& builder) override;
+        void execute(FrameGraphPassExecutionContext& context) override;
+
+    private:
+        SetupFunction setup_;
+        ExecuteFunction execute_;
+    };
+
+    inline RenderPass::RenderPass(std::string name) : name_(std::move(name))
+    {
+    }
+
+    inline std::string_view RenderPass::name() const noexcept
+    {
+        return name_;
+    }
+
+    inline CallbackRenderPass::CallbackRenderPass(std::string name, SetupFunction setup,
+                                                  ExecuteFunction execute)
+        : RenderPass(std::move(name)), setup_(std::move(setup)), execute_(std::move(execute))
+    {
+    }
+
+    inline void CallbackRenderPass::setup(FrameGraphPassBuilder& builder)
+    {
+        if (setup_)
+        {
+            setup_(builder);
+        }
+    }
+
+    inline void CallbackRenderPass::execute(FrameGraphPassExecutionContext& context)
+    {
+        if (execute_)
+        {
+            execute_(context);
+        }
+    }
+} // namespace engine::rendering

--- a/engine/rendering/src/frame_graph.cpp
+++ b/engine/rendering/src/frame_graph.cpp
@@ -1,0 +1,339 @@
+#include "engine/rendering/frame_graph.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace engine::rendering
+{
+    FrameGraphPassBuilder::FrameGraphPassBuilder(FrameGraph& graph, std::size_t pass_index)
+        : graph_(graph), pass_index_(pass_index)
+    {
+    }
+
+    FrameGraphResourceHandle FrameGraphPassBuilder::read(FrameGraphResourceHandle handle)
+    {
+        if (!handle.valid() || handle.index >= graph_.resources_.size())
+        {
+            throw std::out_of_range{"FrameGraphPassBuilder::read received invalid resource handle"};
+        }
+
+        auto& node = graph_.passes_[pass_index_];
+        if (std::find(node.reads.begin(), node.reads.end(), handle) == node.reads.end())
+        {
+            node.reads.push_back(handle);
+        }
+
+        auto& resource = graph_.resources_[handle.index];
+        if (std::find(resource.readers.begin(), resource.readers.end(), pass_index_) == resource.readers.end())
+        {
+            resource.readers.push_back(pass_index_);
+        }
+
+        return handle;
+    }
+
+    FrameGraphResourceHandle FrameGraphPassBuilder::write(FrameGraphResourceHandle handle)
+    {
+        if (!handle.valid() || handle.index >= graph_.resources_.size())
+        {
+            throw std::out_of_range{"FrameGraphPassBuilder::write received invalid resource handle"};
+        }
+
+        auto& node = graph_.passes_[pass_index_];
+        if (std::find(node.writes.begin(), node.writes.end(), handle) == node.writes.end())
+        {
+            node.writes.push_back(handle);
+        }
+
+        auto& resource = graph_.resources_[handle.index];
+        if (resource.writer != std::numeric_limits<std::size_t>::max() && resource.writer != pass_index_)
+        {
+            throw std::logic_error{"FrameGraph resource already has a writer"};
+        }
+        resource.writer = pass_index_;
+
+        return handle;
+    }
+
+    std::string_view FrameGraphPassExecutionContext::pass_name() const
+    {
+        return graph.pass_name(pass_index);
+    }
+
+    std::span<const FrameGraphResourceHandle> FrameGraphPassExecutionContext::reads() const
+    {
+        return graph.pass_reads(pass_index);
+    }
+
+    std::span<const FrameGraphResourceHandle> FrameGraphPassExecutionContext::writes() const
+    {
+        return graph.pass_writes(pass_index);
+    }
+
+    FrameGraphResourceInfo FrameGraphPassExecutionContext::describe(FrameGraphResourceHandle handle) const
+    {
+        return graph.resource_info(handle);
+    }
+
+    FrameGraph::FrameGraph() = default;
+
+    void FrameGraph::reset()
+    {
+        resources_.clear();
+        passes_.clear();
+        execution_order_.clear();
+        resource_events_.clear();
+        compiled_ = false;
+    }
+
+    FrameGraphResourceHandle FrameGraph::create_resource(std::string name, ResourceLifetime lifetime)
+    {
+        compiled_ = false;
+        resources_.push_back(ResourceNode{});
+        auto& node = resources_.back();
+        node.name = std::move(name);
+        node.lifetime = lifetime;
+        return FrameGraphResourceHandle{resources_.size() - 1};
+    }
+
+    std::size_t FrameGraph::add_pass(std::unique_ptr<RenderPass> pass)
+    {
+        if (!pass)
+        {
+            throw std::invalid_argument{"FrameGraph::add_pass expects a valid RenderPass"};
+        }
+
+        compiled_ = false;
+        passes_.push_back(PassNode{});
+        auto& node = passes_.back();
+        node.pass = std::move(pass);
+        const std::size_t index = passes_.size() - 1;
+
+        FrameGraphPassBuilder builder{*this, index};
+        node.pass->setup(builder);
+        return index;
+    }
+
+    void FrameGraph::compile()
+    {
+        execution_order_.clear();
+        resource_events_.clear();
+
+        if (passes_.empty())
+        {
+            compiled_ = true;
+            return;
+        }
+
+        std::vector<std::vector<std::size_t>> adjacency(passes_.size());
+        std::vector<std::size_t> indegree(passes_.size(), 0);
+
+        for (std::size_t resource_index = 0; resource_index < resources_.size(); ++resource_index)
+        {
+            auto& resource = resources_[resource_index];
+            if (resource.writer != std::numeric_limits<std::size_t>::max())
+            {
+                for (std::size_t reader : resource.readers)
+                {
+                    adjacency[resource.writer].push_back(reader);
+                }
+            }
+        }
+
+        for (std::size_t pass_index = 0; pass_index < adjacency.size(); ++pass_index)
+        {
+            auto& edges = adjacency[pass_index];
+            std::sort(edges.begin(), edges.end());
+            edges.erase(std::unique(edges.begin(), edges.end()), edges.end());
+            for (std::size_t target : edges)
+            {
+                ++indegree[target];
+            }
+        }
+
+        std::queue<std::size_t> ready;
+        for (std::size_t i = 0; i < indegree.size(); ++i)
+        {
+            if (indegree[i] == 0)
+            {
+                ready.push(i);
+            }
+        }
+
+        while (!ready.empty())
+        {
+            const std::size_t node_index = ready.front();
+            ready.pop();
+            execution_order_.push_back(node_index);
+
+            for (std::size_t edge : adjacency[node_index])
+            {
+                if (--indegree[edge] == 0)
+                {
+                    ready.push(edge);
+                }
+            }
+        }
+
+        if (execution_order_.size() != passes_.size())
+        {
+            throw std::logic_error{"FrameGraph contains cyclic dependencies"};
+        }
+
+        for (auto& resource : resources_)
+        {
+            resource.first_use = std::numeric_limits<std::size_t>::max();
+            resource.last_use = std::numeric_limits<std::size_t>::max();
+        }
+
+        for (std::size_t order_index = 0; order_index < execution_order_.size(); ++order_index)
+        {
+            const std::size_t pass_index = execution_order_[order_index];
+            const auto& pass = passes_[pass_index];
+
+            auto update_use = [&](FrameGraphResourceHandle handle) {
+                auto& resource = resources_[handle.index];
+                resource.first_use = std::min(resource.first_use, order_index);
+                if (resource.last_use == std::numeric_limits<std::size_t>::max())
+                {
+                    resource.last_use = order_index;
+                }
+                else
+                {
+                    resource.last_use = std::max(resource.last_use, order_index);
+                }
+            };
+
+            for (const auto handle : pass.reads)
+            {
+                update_use(handle);
+            }
+            for (const auto handle : pass.writes)
+            {
+                update_use(handle);
+            }
+        }
+
+        compiled_ = true;
+    }
+
+    void FrameGraph::execute(RenderExecutionContext& context)
+    {
+        if (!compiled_)
+        {
+            compile();
+        }
+
+        if (execution_order_.empty())
+        {
+            return;
+        }
+
+        resource_events_.clear();
+        std::vector<bool> alive(resources_.size(), false);
+
+        for (std::size_t order_index = 0; order_index < execution_order_.size(); ++order_index)
+        {
+            const std::size_t pass_index = execution_order_[order_index];
+            auto& pass = passes_[pass_index];
+
+            auto signal_acquire = [&](FrameGraphResourceHandle handle) {
+                auto& resource = resources_[handle.index];
+                if (resource.lifetime == ResourceLifetime::Transient &&
+                    resource.first_use == order_index && !alive[handle.index])
+                {
+                    alive[handle.index] = true;
+                    resource_events_.push_back(ResourceEvent{ResourceEvent::Type::Acquire, resource.name,
+                                                              std::string(pass.pass->name())});
+                }
+            };
+
+            auto signal_release = [&](FrameGraphResourceHandle handle) {
+                auto& resource = resources_[handle.index];
+                if (resource.lifetime == ResourceLifetime::Transient &&
+                    resource.last_use == order_index && alive[handle.index])
+                {
+                    alive[handle.index] = false;
+                    resource_events_.push_back(ResourceEvent{ResourceEvent::Type::Release, resource.name,
+                                                              std::string(pass.pass->name())});
+                }
+            };
+
+            for (const auto handle : pass.reads)
+            {
+                signal_acquire(handle);
+            }
+
+            FrameGraphPassExecutionContext pass_context{context, *this, pass_index};
+            pass.pass->execute(pass_context);
+
+            for (const auto handle : pass.reads)
+            {
+                signal_release(handle);
+            }
+            for (const auto handle : pass.writes)
+            {
+                signal_acquire(handle);
+            }
+            for (const auto handle : pass.writes)
+            {
+                signal_release(handle);
+            }
+        }
+    }
+
+    const std::vector<std::size_t>& FrameGraph::execution_order() const noexcept
+    {
+        return execution_order_;
+    }
+
+    const std::vector<ResourceEvent>& FrameGraph::resource_events() const noexcept
+    {
+        return resource_events_;
+    }
+
+    FrameGraphResourceInfo FrameGraph::resource_info(FrameGraphResourceHandle handle) const
+    {
+        if (!handle.valid() || handle.index >= resources_.size())
+        {
+            throw std::out_of_range{"FrameGraph::resource_info received invalid handle"};
+        }
+
+        const auto& resource = resources_[handle.index];
+        return FrameGraphResourceInfo{resource.name, resource.lifetime};
+    }
+
+    std::span<const FrameGraphResourceHandle> FrameGraph::pass_reads(std::size_t pass_index)
+    {
+        if (pass_index >= passes_.size())
+        {
+            throw std::out_of_range{"FrameGraph::pass_reads invalid pass index"};
+        }
+
+        return passes_[pass_index].reads;
+    }
+
+    std::span<const FrameGraphResourceHandle> FrameGraph::pass_writes(std::size_t pass_index)
+    {
+        if (pass_index >= passes_.size())
+        {
+            throw std::out_of_range{"FrameGraph::pass_writes invalid pass index"};
+        }
+
+        return passes_[pass_index].writes;
+    }
+
+    std::string_view FrameGraph::pass_name(std::size_t pass_index) const
+    {
+        if (pass_index >= passes_.size())
+        {
+            throw std::out_of_range{"FrameGraph::pass_name invalid pass index"};
+        }
+
+        return passes_[pass_index].pass->name();
+    }
+}

--- a/engine/rendering/src/material_system.cpp
+++ b/engine/rendering/src/material_system.cpp
@@ -1,0 +1,49 @@
+#include "engine/rendering/material_system.hpp"
+
+#include <utility>
+
+namespace engine::rendering
+{
+    void MaterialSystem::register_material(MaterialRecord record)
+    {
+        materials_[record.material] = std::move(record);
+    }
+
+    bool MaterialSystem::has_material(const engine::assets::MaterialHandle& handle) const noexcept
+    {
+        return materials_.find(handle) != materials_.end();
+    }
+
+    std::optional<MaterialSystem::MaterialRecord> MaterialSystem::find(const engine::assets::MaterialHandle& handle) const
+    {
+        if (auto it = materials_.find(handle); it != materials_.end())
+        {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+    void MaterialSystem::ensure_material_loaded(const engine::assets::MaterialHandle& handle,
+                                                RenderResourceProvider& provider)
+    {
+        if (handle.empty())
+        {
+            return;
+        }
+
+        provider.require_material(handle);
+
+        if (auto record = find(handle))
+        {
+            if (!record->shader.empty())
+            {
+                provider.require_shader(record->shader);
+            }
+        }
+    }
+
+    void MaterialSystem::clear() noexcept
+    {
+        materials_.clear();
+    }
+}

--- a/engine/rendering/tests/CMakeLists.txt
+++ b/engine/rendering/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(engine_rendering_tests
     test_module.cpp
+    test_frame_graph.cpp
+    test_forward_pipeline.cpp
 )
 
 set_target_properties(engine_rendering_tests PROPERTIES

--- a/engine/rendering/tests/test_forward_pipeline.cpp
+++ b/engine/rendering/tests/test_forward_pipeline.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "engine/rendering/components.hpp"
+#include "engine/rendering/forward_pipeline.hpp"
+#include "engine/scene/components/transform.hpp"
+#include "engine/scene/scene.hpp"
+
+namespace
+{
+    class RecordingProvider final : public engine::rendering::RenderResourceProvider
+    {
+    public:
+        void require_mesh(const engine::assets::MeshHandle& handle) override
+        {
+            meshes.push_back(handle);
+        }
+
+        void require_material(const engine::assets::MaterialHandle& handle) override
+        {
+            materials.push_back(handle);
+        }
+
+        void require_shader(const engine::assets::ShaderHandle& handle) override
+        {
+            shaders.push_back(handle);
+        }
+
+        std::vector<engine::assets::MeshHandle> meshes;
+        std::vector<engine::assets::MaterialHandle> materials;
+        std::vector<engine::assets::ShaderHandle> shaders;
+    };
+}
+
+TEST(ForwardPipeline, RequestsResourcesForVisibleRenderables)
+{
+    engine::scene::Scene scene;
+    const auto entity = scene.create_entity();
+
+    auto& world = scene.registry().emplace<engine::scene::components::WorldTransform>(entity.id());
+    world.value.translation = engine::math::Vector<float, 3>{1.0F, 2.0F, 3.0F};
+
+    auto& geometry = scene.registry().emplace<engine::rendering::components::RenderGeometry>(entity.id());
+    geometry.mesh = engine::assets::MeshHandle{std::string{"mesh"}};
+    geometry.material = engine::assets::MaterialHandle{std::string{"material"}};
+
+    engine::rendering::MaterialSystem materials;
+    materials.register_material(engine::rendering::MaterialSystem::MaterialRecord{
+        engine::assets::MaterialHandle{std::string{"material"}},
+        engine::assets::ShaderHandle{std::string{"shader"}}
+    });
+
+    engine::rendering::FrameGraph graph;
+    engine::rendering::ForwardPipeline pipeline;
+    RecordingProvider provider;
+
+    pipeline.render(scene, provider, materials, graph);
+
+    ASSERT_EQ(graph.execution_order().size(), 1);  // NOLINT
+    const auto& events = graph.resource_events();
+    ASSERT_EQ(events.size(), 4);  // NOLINT
+
+    EXPECT_EQ(events[0].resource_name, "ForwardColor");
+    EXPECT_EQ(events[0].type, engine::rendering::ResourceEvent::Type::Acquire);
+
+    EXPECT_EQ(events[1].resource_name, "ForwardDepth");
+    EXPECT_EQ(events[1].type, engine::rendering::ResourceEvent::Type::Acquire);
+
+    EXPECT_EQ(events[2].resource_name, "ForwardColor");
+    EXPECT_EQ(events[2].type, engine::rendering::ResourceEvent::Type::Release);
+
+    EXPECT_EQ(events[3].resource_name, "ForwardDepth");
+    EXPECT_EQ(events[3].type, engine::rendering::ResourceEvent::Type::Release);
+
+    ASSERT_EQ(provider.meshes.size(), 1);  // NOLINT
+    EXPECT_EQ(provider.meshes.front().id(), std::string{"mesh"});
+
+    ASSERT_EQ(provider.materials.size(), 1);  // NOLINT
+    EXPECT_EQ(provider.materials.front().id(), std::string{"material"});
+
+    ASSERT_EQ(provider.shaders.size(), 1);  // NOLINT
+    EXPECT_EQ(provider.shaders.front().id(), std::string{"shader"});
+}

--- a/engine/rendering/tests/test_frame_graph.cpp
+++ b/engine/rendering/tests/test_frame_graph.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "engine/rendering/frame_graph.hpp"
+#include "engine/rendering/material_system.hpp"
+#include "engine/rendering/render_pass.hpp"
+#include "engine/scene/scene.hpp"
+
+namespace
+{
+    class NullProvider final : public engine::rendering::RenderResourceProvider
+    {
+    public:
+        void require_mesh(const engine::assets::MeshHandle&) override {}
+        void require_material(const engine::assets::MaterialHandle&) override {}
+        void require_shader(const engine::assets::ShaderHandle&) override {}
+    };
+}
+
+TEST(FrameGraph, SchedulesPassesBasedOnDependencies)
+{
+    engine::rendering::FrameGraph graph;
+    const auto depth = graph.create_resource("Depth");
+    const auto color = graph.create_resource("Color");
+
+    std::vector<std::string> order;
+
+    graph.add_pass(std::make_unique<engine::rendering::CallbackRenderPass>(
+        "DepthPrepass",
+        [=](engine::rendering::FrameGraphPassBuilder& builder) { builder.write(depth); },
+        [&](engine::rendering::FrameGraphPassExecutionContext& context) {
+            order.emplace_back(context.pass_name());
+        }));
+
+    graph.add_pass(std::make_unique<engine::rendering::CallbackRenderPass>(
+        "GBuffer",
+        [=](engine::rendering::FrameGraphPassBuilder& builder) {
+            builder.read(depth);
+            builder.write(color);
+        },
+        [&](engine::rendering::FrameGraphPassExecutionContext& context) {
+            order.emplace_back(context.pass_name());
+        }));
+
+    graph.add_pass(std::make_unique<engine::rendering::CallbackRenderPass>(
+        "Lighting",
+        [=](engine::rendering::FrameGraphPassBuilder& builder) { builder.read(color); },
+        [&](engine::rendering::FrameGraphPassExecutionContext& context) {
+            order.emplace_back(context.pass_name());
+        }));
+
+    graph.compile();
+
+    engine::scene::Scene scene;
+    engine::rendering::MaterialSystem materials;
+    NullProvider provider;
+    engine::rendering::RenderExecutionContext context{provider, materials, engine::rendering::RenderView{scene}};
+    graph.execute(context);
+
+    ASSERT_EQ(order.size(), 3);  // NOLINT
+    EXPECT_EQ(order[0], "DepthPrepass");
+    EXPECT_EQ(order[1], "GBuffer");
+    EXPECT_EQ(order[2], "Lighting");
+}
+
+TEST(FrameGraph, TracksResourceLifetimes)
+{
+    engine::rendering::FrameGraph graph;
+    const auto depth = graph.create_resource("Depth");
+    const auto color = graph.create_resource("Color");
+
+    graph.add_pass(std::make_unique<engine::rendering::CallbackRenderPass>(
+        "DepthPrepass",
+        [=](engine::rendering::FrameGraphPassBuilder& builder) { builder.write(depth); },
+        [](engine::rendering::FrameGraphPassExecutionContext&) {}));
+
+    graph.add_pass(std::make_unique<engine::rendering::CallbackRenderPass>(
+        "GBuffer",
+        [=](engine::rendering::FrameGraphPassBuilder& builder) {
+            builder.read(depth);
+            builder.write(color);
+        },
+        [](engine::rendering::FrameGraphPassExecutionContext&) {}));
+
+    graph.add_pass(std::make_unique<engine::rendering::CallbackRenderPass>(
+        "Lighting",
+        [=](engine::rendering::FrameGraphPassBuilder& builder) { builder.read(color); },
+        [](engine::rendering::FrameGraphPassExecutionContext&) {}));
+
+    graph.compile();
+
+    engine::scene::Scene scene;
+    engine::rendering::MaterialSystem materials;
+    NullProvider provider;
+    engine::rendering::RenderExecutionContext context{provider, materials, engine::rendering::RenderView{scene}};
+    graph.execute(context);
+
+    const auto& events = graph.resource_events();
+    ASSERT_EQ(events.size(), 4);  // NOLINT
+
+    EXPECT_EQ(events[0].type, engine::rendering::ResourceEvent::Type::Acquire);
+    EXPECT_EQ(events[0].resource_name, "Depth");
+    EXPECT_EQ(events[0].pass_name, "DepthPrepass");
+
+    EXPECT_EQ(events[1].type, engine::rendering::ResourceEvent::Type::Release);
+    EXPECT_EQ(events[1].resource_name, "Depth");
+    EXPECT_EQ(events[1].pass_name, "GBuffer");
+
+    EXPECT_EQ(events[2].type, engine::rendering::ResourceEvent::Type::Acquire);
+    EXPECT_EQ(events[2].resource_name, "Color");
+    EXPECT_EQ(events[2].pass_name, "GBuffer");
+
+    EXPECT_EQ(events[3].type, engine::rendering::ResourceEvent::Type::Release);
+    EXPECT_EQ(events[3].resource_name, "Color");
+    EXPECT_EQ(events[3].pass_name, "Lighting");
+}


### PR DESCRIPTION
## Summary
- add public rendering interfaces for the frame graph, render passes, and material system
- implement the frame graph scheduler, resource lifetime tracking, and a minimal forward rendering pipeline
- cover the new systems with unit tests for pass ordering, resource lifetimes, and forward pipeline resource requests

## Testing
- cmake --build build --target engine_rendering_tests
- ctest --test-dir build/engine/rendering/tests -V

------
https://chatgpt.com/codex/tasks/task_e_68e4f1755c088320b420a9792da81b82