### PR TITLE
Extend rendering pipeline to support graphs and point clouds

### DIFF
--- a/engine/assets/include/engine/assets/handles.hpp
+++ b/engine/assets/include/engine/assets/handles.hpp
@@ -50,11 +50,15 @@ namespace engine::assets
     };
 
     struct MeshTag;
+    struct GraphTag;
+    struct PointCloudTag;
     struct TextureTag;
     struct ShaderTag;
     struct MaterialTag;
 
     using MeshHandle = AssetHandle<MeshTag>;
+    using GraphHandle = AssetHandle<GraphTag>;
+    using PointCloudHandle = AssetHandle<PointCloudTag>;
     using TextureHandle = AssetHandle<TextureTag>;
     using ShaderHandle = AssetHandle<ShaderTag>;
     using MaterialHandle = AssetHandle<MaterialTag>;

--- a/engine/rendering/include/engine/rendering/components.hpp
+++ b/engine/rendering/include/engine/rendering/components.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <variant>
+
 #include "engine/assets/handles.hpp"
 
 namespace engine::rendering::components
@@ -14,10 +16,39 @@ namespace engine::rendering::components
      */
     struct RenderGeometry
     {
-        /// Handle of the mesh asset containing vertex and index buffers.
-        engine::assets::MeshHandle mesh{};
+        using Geometry = std::variant<std::monostate, engine::assets::MeshHandle, engine::assets::GraphHandle,
+                                      engine::assets::PointCloudHandle>;
 
-        /// Handle of the material definition to bind when the mesh is drawn.
+        RenderGeometry() = default;
+
+        static RenderGeometry from_mesh(engine::assets::MeshHandle mesh,
+                                        engine::assets::MaterialHandle material = {});
+
+        static RenderGeometry from_graph(engine::assets::GraphHandle graph,
+                                         engine::assets::MaterialHandle material = {});
+
+        static RenderGeometry from_point_cloud(engine::assets::PointCloudHandle point_cloud,
+                                               engine::assets::MaterialHandle material = {});
+
+        [[nodiscard]] bool empty() const noexcept;
+        [[nodiscard]] bool has_mesh() const noexcept;
+        [[nodiscard]] bool has_graph() const noexcept;
+        [[nodiscard]] bool has_point_cloud() const noexcept;
+
+        [[nodiscard]] const engine::assets::MeshHandle* mesh() const noexcept;
+        [[nodiscard]] const engine::assets::GraphHandle* graph() const noexcept;
+        [[nodiscard]] const engine::assets::PointCloudHandle* point_cloud() const noexcept;
+
+        [[nodiscard]] const Geometry& geometry() const noexcept { return geometry_; }
+
+        /// Handle of the material definition to bind when the geometry is drawn.
         engine::assets::MaterialHandle material{};
+
+    private:
+        explicit RenderGeometry(Geometry geometry, engine::assets::MaterialHandle material) noexcept;
+
+        Geometry geometry_{};
     };
-} // namespace engine::rendering::components
+}
+
+#include "engine/rendering/components.inl"

--- a/engine/rendering/include/engine/rendering/components.inl
+++ b/engine/rendering/include/engine/rendering/components.inl
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <utility>
+
+namespace engine::rendering::components
+{
+    inline RenderGeometry::RenderGeometry(Geometry geometry, engine::assets::MaterialHandle material) noexcept
+        : material(std::move(material)), geometry_(std::move(geometry))
+    {
+    }
+
+    inline RenderGeometry RenderGeometry::from_mesh(engine::assets::MeshHandle mesh,
+                                                    engine::assets::MaterialHandle material)
+    {
+        return RenderGeometry{std::move(mesh), std::move(material)};
+    }
+
+    inline RenderGeometry RenderGeometry::from_graph(engine::assets::GraphHandle graph,
+                                                     engine::assets::MaterialHandle material)
+    {
+        return RenderGeometry{std::move(graph), std::move(material)};
+    }
+
+    inline RenderGeometry RenderGeometry::from_point_cloud(engine::assets::PointCloudHandle point_cloud,
+                                                           engine::assets::MaterialHandle material)
+    {
+        return RenderGeometry{std::move(point_cloud), std::move(material)};
+    }
+
+    inline bool RenderGeometry::empty() const noexcept
+    {
+        return std::holds_alternative<std::monostate>(geometry_);
+    }
+
+    inline bool RenderGeometry::has_mesh() const noexcept
+    {
+        return std::holds_alternative<engine::assets::MeshHandle>(geometry_);
+    }
+
+    inline bool RenderGeometry::has_graph() const noexcept
+    {
+        return std::holds_alternative<engine::assets::GraphHandle>(geometry_);
+    }
+
+    inline bool RenderGeometry::has_point_cloud() const noexcept
+    {
+        return std::holds_alternative<engine::assets::PointCloudHandle>(geometry_);
+    }
+
+    inline const engine::assets::MeshHandle* RenderGeometry::mesh() const noexcept
+    {
+        return std::get_if<engine::assets::MeshHandle>(&geometry_);
+    }
+
+    inline const engine::assets::GraphHandle* RenderGeometry::graph() const noexcept
+    {
+        return std::get_if<engine::assets::GraphHandle>(&geometry_);
+    }
+
+    inline const engine::assets::PointCloudHandle* RenderGeometry::point_cloud() const noexcept
+    {
+        return std::get_if<engine::assets::PointCloudHandle>(&geometry_);
+    }
+}

--- a/engine/rendering/include/engine/rendering/render_pass.hpp
+++ b/engine/rendering/include/engine/rendering/render_pass.hpp
@@ -30,6 +30,12 @@ namespace engine::rendering
         /// Ensure that the mesh identified by \p handle is resident on the GPU.
         virtual void require_mesh(const engine::assets::MeshHandle& handle) = 0;
 
+        /// Ensure that the graph identified by \p handle is resident on the GPU.
+        virtual void require_graph(const engine::assets::GraphHandle& handle) = 0;
+
+        /// Ensure that the point cloud identified by \p handle is resident on the GPU.
+        virtual void require_point_cloud(const engine::assets::PointCloudHandle& handle) = 0;
+
         /// Ensure that the material identified by \p handle is ready for use.
         virtual void require_material(const engine::assets::MaterialHandle& handle) = 0;
 

--- a/engine/rendering/src/forward_pipeline.cpp
+++ b/engine/rendering/src/forward_pipeline.cpp
@@ -39,9 +39,18 @@ namespace engine::rendering
 
                 for (auto [entity, world, geometry] : view.each())
                 {
-                    if (!geometry.mesh.empty())
+                    if (const auto* mesh = geometry.mesh(); mesh != nullptr && !mesh->empty())
                     {
-                        context.render.resources.require_mesh(geometry.mesh);
+                        context.render.resources.require_mesh(*mesh);
+                    }
+                    else if (const auto* graph = geometry.graph(); graph != nullptr && !graph->empty())
+                    {
+                        context.render.resources.require_graph(*graph);
+                    }
+                    else if (const auto* point_cloud = geometry.point_cloud();
+                             point_cloud != nullptr && !point_cloud->empty())
+                    {
+                        context.render.resources.require_point_cloud(*point_cloud);
                     }
 
                     if (!geometry.material.empty())
@@ -49,13 +58,14 @@ namespace engine::rendering
                         context.render.materials.ensure_material_loaded(geometry.material, context.render.resources);
                     }
 
-                    draw_commands_.push_back(DrawCommand{geometry.mesh, geometry.material, world.value});
+                    draw_commands_.push_back(
+                        DrawCommand{geometry.geometry(), geometry.material, world.value});
                 }
             }
 
             struct DrawCommand
             {
-                engine::assets::MeshHandle mesh;
+                components::RenderGeometry::Geometry geometry;
                 engine::assets::MaterialHandle material;
                 engine::math::Transform<float> transform;
             };

--- a/engine/rendering/tests/test_forward_pipeline.cpp
+++ b/engine/rendering/tests/test_forward_pipeline.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <gtest/gtest.h>
 
 #include <string>
@@ -18,6 +19,16 @@ namespace
             meshes.push_back(handle);
         }
 
+        void require_graph(const engine::assets::GraphHandle& handle) override
+        {
+            graphs.push_back(handle);
+        }
+
+        void require_point_cloud(const engine::assets::PointCloudHandle& handle) override
+        {
+            point_clouds.push_back(handle);
+        }
+
         void require_material(const engine::assets::MaterialHandle& handle) override
         {
             materials.push_back(handle);
@@ -29,6 +40,8 @@ namespace
         }
 
         std::vector<engine::assets::MeshHandle> meshes;
+        std::vector<engine::assets::GraphHandle> graphs;
+        std::vector<engine::assets::PointCloudHandle> point_clouds;
         std::vector<engine::assets::MaterialHandle> materials;
         std::vector<engine::assets::ShaderHandle> shaders;
     };
@@ -37,19 +50,48 @@ namespace
 TEST(ForwardPipeline, RequestsResourcesForVisibleRenderables)
 {
     engine::scene::Scene scene;
-    const auto entity = scene.create_entity();
+    const auto mesh_entity = scene.create_entity();
+    auto& mesh_world =
+        scene.registry().emplace<engine::scene::components::WorldTransform>(mesh_entity.id());
+    mesh_world.value.translation = engine::math::Vector<float, 3>{1.0F, 2.0F, 3.0F};
+    scene.registry().emplace<engine::rendering::components::RenderGeometry>(
+        mesh_entity.id(),
+        engine::rendering::components::RenderGeometry::from_mesh(
+            engine::assets::MeshHandle{std::string{"mesh"}},
+            engine::assets::MaterialHandle{std::string{"mesh_material"}}));
 
-    auto& world = scene.registry().emplace<engine::scene::components::WorldTransform>(entity.id());
-    world.value.translation = engine::math::Vector<float, 3>{1.0F, 2.0F, 3.0F};
+    const auto graph_entity = scene.create_entity();
+    auto& graph_world =
+        scene.registry().emplace<engine::scene::components::WorldTransform>(graph_entity.id());
+    graph_world.value.translation = engine::math::Vector<float, 3>{-1.0F, 0.5F, 4.0F};
+    scene.registry().emplace<engine::rendering::components::RenderGeometry>(
+        graph_entity.id(),
+        engine::rendering::components::RenderGeometry::from_graph(
+            engine::assets::GraphHandle{std::string{"graph"}},
+            engine::assets::MaterialHandle{std::string{"graph_material"}}));
 
-    auto& geometry = scene.registry().emplace<engine::rendering::components::RenderGeometry>(entity.id());
-    geometry.mesh = engine::assets::MeshHandle{std::string{"mesh"}};
-    geometry.material = engine::assets::MaterialHandle{std::string{"material"}};
+    const auto cloud_entity = scene.create_entity();
+    auto& cloud_world =
+        scene.registry().emplace<engine::scene::components::WorldTransform>(cloud_entity.id());
+    cloud_world.value.translation = engine::math::Vector<float, 3>{0.0F, -3.0F, -1.0F};
+    scene.registry().emplace<engine::rendering::components::RenderGeometry>(
+        cloud_entity.id(),
+        engine::rendering::components::RenderGeometry::from_point_cloud(
+            engine::assets::PointCloudHandle{std::string{"cloud"}},
+            engine::assets::MaterialHandle{std::string{"cloud_material"}}));
 
     engine::rendering::MaterialSystem materials;
     materials.register_material(engine::rendering::MaterialSystem::MaterialRecord{
-        engine::assets::MaterialHandle{std::string{"material"}},
-        engine::assets::ShaderHandle{std::string{"shader"}}
+        engine::assets::MaterialHandle{std::string{"mesh_material"}},
+        engine::assets::ShaderHandle{std::string{"mesh_shader"}}
+    });
+    materials.register_material(engine::rendering::MaterialSystem::MaterialRecord{
+        engine::assets::MaterialHandle{std::string{"graph_material"}},
+        engine::assets::ShaderHandle{std::string{"graph_shader"}}
+    });
+    materials.register_material(engine::rendering::MaterialSystem::MaterialRecord{
+        engine::assets::MaterialHandle{std::string{"cloud_material"}},
+        engine::assets::ShaderHandle{std::string{"cloud_shader"}}
     });
 
     engine::rendering::FrameGraph graph;
@@ -77,9 +119,31 @@ TEST(ForwardPipeline, RequestsResourcesForVisibleRenderables)
     ASSERT_EQ(provider.meshes.size(), 1);  // NOLINT
     EXPECT_EQ(provider.meshes.front().id(), std::string{"mesh"});
 
-    ASSERT_EQ(provider.materials.size(), 1);  // NOLINT
-    EXPECT_EQ(provider.materials.front().id(), std::string{"material"});
+    ASSERT_EQ(provider.graphs.size(), 1);  // NOLINT
+    EXPECT_EQ(provider.graphs.front().id(), std::string{"graph"});
 
-    ASSERT_EQ(provider.shaders.size(), 1);  // NOLINT
-    EXPECT_EQ(provider.shaders.front().id(), std::string{"shader"});
+    ASSERT_EQ(provider.point_clouds.size(), 1);  // NOLINT
+    EXPECT_EQ(provider.point_clouds.front().id(), std::string{"cloud"});
+
+    ASSERT_EQ(provider.materials.size(), 3);  // NOLINT
+    EXPECT_TRUE(std::find(provider.materials.begin(), provider.materials.end(),
+                          engine::assets::MaterialHandle{std::string{"mesh_material"}})
+                != provider.materials.end());
+    EXPECT_TRUE(std::find(provider.materials.begin(), provider.materials.end(),
+                          engine::assets::MaterialHandle{std::string{"graph_material"}})
+                != provider.materials.end());
+    EXPECT_TRUE(std::find(provider.materials.begin(), provider.materials.end(),
+                          engine::assets::MaterialHandle{std::string{"cloud_material"}})
+                != provider.materials.end());
+
+    ASSERT_EQ(provider.shaders.size(), 3);  // NOLINT
+    EXPECT_TRUE(std::find(provider.shaders.begin(), provider.shaders.end(),
+                          engine::assets::ShaderHandle{std::string{"mesh_shader"}})
+                != provider.shaders.end());
+    EXPECT_TRUE(std::find(provider.shaders.begin(), provider.shaders.end(),
+                          engine::assets::ShaderHandle{std::string{"graph_shader"}})
+                != provider.shaders.end());
+    EXPECT_TRUE(std::find(provider.shaders.begin(), provider.shaders.end(),
+                          engine::assets::ShaderHandle{std::string{"cloud_shader"}})
+                != provider.shaders.end());
 }

--- a/engine/rendering/tests/test_frame_graph.cpp
+++ b/engine/rendering/tests/test_frame_graph.cpp
@@ -15,6 +15,8 @@ namespace
     {
     public:
         void require_mesh(const engine::assets::MeshHandle&) override {}
+        void require_graph(const engine::assets::GraphHandle&) override {}
+        void require_point_cloud(const engine::assets::PointCloudHandle&) override {}
         void require_material(const engine::assets::MaterialHandle&) override {}
         void require_shader(const engine::assets::ShaderHandle&) override {}
     };


### PR DESCRIPTION
## Summary
- add graph and point cloud asset handle types so non-mesh geometry can be addressed
- generalize the RenderGeometry component to carry mesh, graph, or point cloud payloads and expose helpers
- broaden the render resource provider contract, forward pipeline, and tests to request the correct resources for all geometry kinds

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e5021e9714832089da895a7ab9efd9