### PR TITLE
Refresh documentation across subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ core (`engine/`), tooling (`python/`, `scripts/`), and project documentation (`d
 
 ## Top-level Layout
 
-- `docs/` – Design notes and API references that describe the evolving architecture.
+- `docs/` – Design notes, API references, and validation utilities that describe the evolving architecture.
 - `engine/` – C++ engine source organised by subsystem (animation, rendering, physics, etc.).
 - `python/` – Python bindings and companion utilities for automation and prototyping.
-- `scripts/` – Developer tooling for builds and continuous integration jobs.
-- `third_party/` – External dependencies vendored into the workspace (currently GoogleTest).
+- `scripts/` – Developer tooling for builds, continuous integration jobs, and documentation validation.
+- `third_party/` – External dependencies vendored into the workspace (EnTT, Dear ImGui, spdlog, GoogleTest).
 - `CMakeLists.txt` – Root CMake project file that wires the modular subprojects together.
 - `CODING_STYLE.md` – Canonical formatting and style conventions for contributions.
 
@@ -57,7 +57,18 @@ cmake -S . -B build
 cmake --build build
 ```
 
-Tests are provided via GoogleTest. Once the project is built, execute `ctest --test-dir build` to run the available
-suites.
+## Testing
 
-_Last updated: 2025-10-05_
+- **C++** – After building with CMake, run `ctest --test-dir build` to execute the GoogleTest suites that ship with the
+  engine modules (e.g., math numerics, geometry kernels).
+- **Python** – Run `pytest` from the repository root to exercise the `engine3g.loader` helpers and ensure shared library
+  discovery behaviour remains stable.
+
+## Tooling and Dependencies
+
+- Third-party libraries are vendored under `third_party/` and currently include [EnTT](https://github.com/skypjack/entt),
+  [Dear ImGui](https://github.com/ocornut/imgui), [spdlog](https://github.com/gabime/spdlog), and
+  [GoogleTest](https://github.com/google/googletest).
+- Documentation links can be validated offline with `python scripts/validate_docs.py`.
+
+_Last updated: 2025-02-14_

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ The `docs/` subtree aggregates written documentation for the engine project.
   - [Scene Module](api/scene.md)
 - [`design/`](design/README.md) – Architectural sketches, diagrams, and exploratory design documents.
   - [Engine Architecture Overview](design/architecture.md)
+- Validation utilities – `scripts/validate_docs.py` traverses Markdown files and verifies that relative links
+  resolve inside the repository.
 
 Each nested directory provides its own README for finer-grained navigation.
 
@@ -17,7 +19,7 @@ Each nested directory provides its own README for finer-grained navigation.
   links to the relevant headers or source files so reviewers can trace the implementation.
 - Keep cross-links relative (e.g., `../../engine/...`) to ensure they remain valid when the repository is
   relocated.
-- Run the `docs` CMake target (see below) before submitting a change; it validates that all referenced files
-  exist.
+- Before submitting a change, run `python scripts/validate_docs.py` from the repository root to make sure all
+  documentation links resolve.
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-02-14_

--- a/engine/README.md
+++ b/engine/README.md
@@ -7,17 +7,19 @@ The `engine/` subtree contains the core C++ implementation of the engine. Each s
 - `assets/` – Asset pipelines, sample content, and shader packaging.
 - `compute/` – Heterogeneous compute backends (CUDA and generic dispatch infrastructure).
 - `core/` – Foundational runtime services, configuration, diagnostics, and ECS primitives.
-- `geometry/` – Mesh processing, topology utilities, and geometric algorithms.
+- `geometry/` – Mesh processing, topology utilities, surface/volume representations, and discrete differential
+  geometry algorithms.
 - `io/` – Import/export modules and caching layers for content.
-- `math/` – Shared mathematical utilities.
+- `math/` – Shared mathematical utilities (vectors, matrices, quaternions, transforms, camera helpers).
 - `physics/` – Collision detection and dynamics scaffolding.
 - `platform/` – Abstractions for windowing, input, and file systems.
 - `rendering/` – Rendering pipeline layers, material systems, and backend integrations.
-- `runtime/` – Application glue that stitches systems together.
-- `scene/` – Scene graph, component registration, and serialization.
-- `tests/` – Unit, integration, and performance test suites organised by subsystem.
+- `runtime/` – Application glue that stitches systems together and exposes a shared-library discovery surface.
+- `scene/` – Scene graph, component registration, and serialization built around EnTT.
+- `tests/` – Unit, integration, and performance test suites organised by subsystem (math numerics enabled today).
 - `tools/` – Developer tooling (profilers, content pipelines, and editor stubs).
 
-A top-level `CMakeLists.txt` exposes each subsystem to the global build configuration.
+A top-level `CMakeLists.txt` exposes each subsystem to the global build configuration. Build targets follow the
+`engine_<subsystem>` naming convention so they can be located dynamically by the runtime loader.
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-02-14_

--- a/engine/geometry/README.md
+++ b/engine/geometry/README.md
@@ -2,24 +2,34 @@
 
 _Path: `engine/geometry`_
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-02-14_
 
 
-## Contents
+## Overview
 
-### Subdirectories
+The geometry module implements the surface and volumetric kernels required by the engine. Key facilities include:
 
-- `csg/` – documented in its own README; contains 1 file.
-- `decimation/` – documented in its own README; contains 1 file.
-- `include/` – contains 1 subdirectory.
-- `mesh/` – documented in its own README; contains 1 file.
-- `src/` – documented in its own README; contains 6 subdirectories; contains 1 file.
-- `surfaces/` – documented in its own README; contains 1 file.
-- `tests/` – documented in its own README; contains 8 files.
-- `topology/` – documented in its own README; contains 1 file.
-- `uv/` – documented in its own README; contains 1 file.
-- `volumetric/` – documented in its own README; contains 1 file.
+- A half-edge mesh core with property maps (`include/engine/geometry/mesh/halfedge_mesh.hpp`) supporting arbitrary
+  attribute attachment.
+- Generic property registries that expose strongly-typed handles for component data.
+- Basic analytic shapes (sphere, cylinder, ray) and point-cloud containers for procedural content and intersection
+  testing.
+- Surface sampling, decimation, UV unwrapping, and topology helpers under the `src/` subtree.
 
-### Files
+## Usage
 
-- `CMakeLists.txt` – Text resource.
+Link against `engine_geometry` and include headers from `include/engine/geometry/`:
+
+```cmake
+target_link_libraries(my_app PRIVATE engine_geometry)
+```
+
+```cpp
+#include <engine/geometry/mesh/halfedge_mesh.hpp>
+
+engine::geometry::HalfedgeMesh mesh;
+auto position = mesh.request_vertex_property<engine::math::vec3>("v:position");
+```
+
+The accompanying GoogleTest suites under `tests/` exercise mesh traversal, property registry lifetime semantics, and
+discrete differential geometry utilities.

--- a/engine/math/README.md
+++ b/engine/math/README.md
@@ -2,16 +2,35 @@
 
 _Path: `engine/math`_
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-02-14_
 
 
-## Contents
+## Overview
 
-### Subdirectories
+The math module defines the numeric building blocks used throughout the engine. It currently ships a header-only linear
+algebra layer with:
 
-- `include/` – contains 1 subdirectory.
-- `tests/` – documented in its own README; contains 2 files.
+- Fixed-size `Vector`/`Matrix` templates with SIMD-friendly layouts and aliases (`vec3`, `mat4`, ...).
+- Quaternion primitives with conversions to and from angle-axis and Cayley parameterisations.
+- Affine `Transform` structures combining scale, rotation, and translation along with helpers for composition and
+  inversion.
+- Camera utilities (projection matrices, view transforms) and rotation helpers shared with the rendering stack.
 
-### Files
+All public headers live under `include/engine/math/`. The accompanying GoogleTest suite (`tests/test_math.cpp`)
+validates vector algebra, quaternion conversions, and transform matrix round-trips.
 
-- `CMakeLists.txt` – Text resource.
+## Usage
+
+Add the `engine_math` target to your CMake project and include the headers directly:
+
+```cmake
+target_link_libraries(my_app PRIVATE engine_math)
+```
+
+```cpp
+#include <engine/math/vector.hpp>
+#include <engine/math/transform.hpp>
+
+engine::math::vec3 velocity{1.0f, 0.0f, 0.0f};
+auto position = engine::math::transform_point(transform, velocity);
+```

--- a/engine/tests/README.md
+++ b/engine/tests/README.md
@@ -2,13 +2,18 @@
 
 _Path: `engine/tests`_
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-02-14_
 
 
-## Contents
+## Overview
 
-### Subdirectories
+The `engine/tests/` subtree reserves space for cross-module test harnesses. While the current focus is on the
+module-specific suites that live beside their respective code (e.g., `engine/math/tests`), these directories outline how
+larger-scale testing will evolve:
 
-- `integration/` – documented in its own README; contains 1 file.
-- `performance/` – documented in its own README; contains 1 file.
-- `unit/` – documented in its own README; contains 1 file.
+- `unit/` – Aggregates focused unit tests that span multiple engine modules.
+- `integration/` – Targets end-to-end scenarios such as loading scenes through the runtime façade.
+- `performance/` – Hosts micro-benchmarks and performance regression harnesses.
+
+Each directory contains a stub README and `.gitkeep` placeholder to aid future expansion. When promoting tests into this
+hierarchy ensure they are registered with CTest inside the corresponding `CMakeLists.txt`.

--- a/python/README.md
+++ b/python/README.md
@@ -3,7 +3,32 @@
 Python utilities complement the C++ engine. They facilitate automation, experimental scripting, and bindings.
 
 ## Layout
-- `engine3g/` – Python package stubs for engine bindings.
+- `engine3g/` – Python package exposing shared-library loading helpers and future binding entry points.
 - `tests/` – Automated tests for the Python-facing APIs (currently `test_loader.py`).
 
-_Last updated: 2025-10-05_
+## Getting Started
+
+Create a virtual environment targeting Python 3.12 (or later), install development requirements if needed, and run the
+test suite:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt  # when the package list becomes available
+pytest
+```
+
+To experiment with the loader manually:
+
+```python
+from engine3g import loader
+
+runtime = loader.load_runtime()
+modules = runtime.load_modules()
+print(runtime.name(), modules.keys())
+```
+
+Set the `ENGINE3G_LIBRARY_PATH` environment variable (colon-separated on POSIX, semicolon-separated on Windows) to point
+at directories containing the compiled engine shared libraries when testing against native builds.
+
+_Last updated: 2025-02-14_

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,11 @@ Automation helpers for building and validating the workspace live under `scripts
 - `build/` – Scripts and notes for local build workflows.
 - `ci/` – Continuous integration helpers.
 
+## Standalone utilities
+
+- `validate_docs.py` – Checks every Markdown file under `docs/` and reports missing or out-of-repository links.
+  Execute via `python scripts/validate_docs.py` before publishing documentation changes.
+
 Top-level scripts complement the CMake build and documentation maintenance tasks.
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-02-14_

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -3,9 +3,11 @@
 External libraries vendored into the repository are tracked here. Each dependency provides its own README for usage details.
 
 ## Current Dependencies
-- `googletest/` – Upstream GoogleTest source and headers for unit testing.
-- `entt/` – Fast and reliable Entity-Component-System (ECS) library.
-- `imgui/` – Bloat-free Immediate Mode Graphical User interface for C++
-- `spdlog/` – Fast C++ logging library. 
+- `entt/` – Fast and reliable Entity-Component-System (ECS) library that underpins the scene subsystem.
+- `imgui/` – Bloat-free Immediate Mode Graphical User interface for C++ used by the tooling experiments.
+- `spdlog/` – Fast C++ logging library shared by runtime and diagnostics layers.
+- `googletest/` – Upstream GoogleTest source and headers for unit testing across C++ modules.
 
-_Last updated: 2025-10-06_
+Each directory mirrors the upstream project layout and is consumed via add_subdirectory within the CMake build.
+
+_Last updated: 2025-02-14_


### PR DESCRIPTION
## Summary
- update top-level and subsystem README files to describe current layout, tooling, and dependencies
- expand math and geometry module notes with usage guidance and testing context
- document available scripts and python workflows, including doc link validation utility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5640639388320a30f2995f0712ba6