### PR TITLE
Simplify scene include directives

### DIFF
--- a/engine/scene/README.md
+++ b/engine/scene/README.md
@@ -20,3 +20,16 @@ _Last updated: 2025-10-05_
 ### Files
 
 - `CMakeLists.txt` – Text resource.
+
+## Public headers
+
+The scene module exposes both its root directory and the `include/` tree as
+public include directories. This allows client code to include implementation
+details such as
+
+```cpp
+#include "components/hierarchy.hpp"
+#include "systems/registry.hpp"
+```
+
+without relying on fragile, relative paths.

--- a/engine/scene/include/engine/scene/components.hpp
+++ b/engine/scene/include/engine/scene/components.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-#include "../../../components/hierarchy.hpp"
-#include "../../../components/name.hpp"
-#include "../../../components/transform.hpp"
+#include "components/hierarchy.hpp"
+#include "components/name.hpp"
+#include "components/transform.hpp"

--- a/engine/scene/include/engine/scene/systems.hpp
+++ b/engine/scene/include/engine/scene/systems.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-#include "../../../systems/hierarchy_system.hpp"
-#include "../../../systems/registry.hpp"
-#include "../../../systems/transform_system.hpp"
+#include "systems/hierarchy_system.hpp"
+#include "systems/registry.hpp"
+#include "systems/transform_system.hpp"


### PR DESCRIPTION
## Summary
- replace brittle relative include paths in the scene aggregation headers with module-root includes
- document the module's public include layout so consumers know the stable paths

## Testing
- not run (header/doc updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e57fe808e48320a3f61d4a258eeac9