### PR TITLE
Add validation coverage for frame graph and tooling

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ your `PATH`.
 ## Build/Test Commands
 
 - `python scripts/validate_docs.py` – Validates Markdown links across `docs/`.
+- `pytest scripts/tests` – Runs unit tests that exercise the documentation validator helpers.
 - See `scripts/build/README.md` and `scripts/ci/README.md` for subsystem-specific commands.
 
 _Last updated: 2025-02-14_

--- a/scripts/tests/test_validate_docs.py
+++ b/scripts/tests/test_validate_docs.py
@@ -1,0 +1,55 @@
+"""Tests for the documentation validation script."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+import sys
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+validate_docs = import_module("scripts.validate_docs")
+
+
+def test_should_skip_detects_external_targets() -> None:
+    assert validate_docs._should_skip("https://example.com")
+    assert validate_docs._should_skip("http://example.com")
+    assert validate_docs._should_skip("mailto:info@example.com")
+    assert validate_docs._should_skip("#section")
+
+
+def test_validate_markdown_flags_missing_and_outside(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = tmp_path
+    docs_dir = repo_root / "docs"
+    docs_dir.mkdir()
+    nested = docs_dir / "guide"
+    nested.mkdir()
+
+    markdown = nested / "sample.md"
+    markdown.write_text(
+        "\n".join(
+            [
+                "# Sample",
+                "Missing link [Missing](missing.md)",
+                "Outside link [Outside](../../../outside.md)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(validate_docs, "ROOT", repo_root)
+    monkeypatch.setattr(validate_docs, "DOCS_DIR", docs_dir)
+
+    issues = validate_docs._validate_markdown(markdown)
+
+    relative_path = markdown.relative_to(repo_root)
+    expected = {
+        f"{relative_path} -> missing.md (missing)",
+        f"{relative_path} -> ../../../outside.md (outside repository)",
+    }
+
+    assert set(issues) == expected

--- a/third_party/googletest/include/gtest/gtest.h
+++ b/third_party/googletest/include/gtest/gtest.h
@@ -313,6 +313,35 @@ namespace testing
         }                                                                               \
     } while (false)
 
+#define EXPECT_THROW(statement, expected_exception)                                                   \
+    do {                                                                                              \
+        bool gtest_caught_expected = false;                                                            \
+        bool gtest_caught_other = false;                                                               \
+        try {                                                                                          \
+            (void)(statement);                                                                         \
+        } catch (const expected_exception&) {                                                          \
+            gtest_caught_expected = true;                                                              \
+        } catch (const std::exception& gtest_other) {                                                  \
+            gtest_caught_other = true;                                                                 \
+            std::ostringstream gtest_message;                                                          \
+            gtest_message << "Expected exception of type " << #expected_exception                      \
+                          << " but caught std::exception: " << gtest_other.what();                    \
+            ::testing::internal::ReportFailure(__FILE__, __LINE__, gtest_message.str());               \
+        } catch (...) {                                                                                \
+            gtest_caught_other = true;                                                                 \
+            std::ostringstream gtest_message;                                                          \
+            gtest_message << "Expected exception of type " << #expected_exception                      \
+                          << " but caught an unknown exception type.";                               \
+            ::testing::internal::ReportFailure(__FILE__, __LINE__, gtest_message.str());               \
+        }                                                                                              \
+        if (!gtest_caught_expected && !gtest_caught_other) {                                           \
+            std::ostringstream gtest_message;                                                          \
+            gtest_message << "Expected exception of type " << #expected_exception                      \
+                          << " to be thrown.";                                                        \
+            ::testing::internal::ReportFailure(__FILE__, __LINE__, gtest_message.str());               \
+        }                                                                                              \
+    } while (false)
+
 #define ASSERT_TRUE(condition)                                                                           \
     do {                                                                                                  \
         const bool gtest_condition = static_cast<bool>(condition);                                        \


### PR DESCRIPTION
## Summary
- add regression coverage for FrameGraph error handling paths
- extend loader tests to verify null metadata handling and filtered module lists
- add pytest coverage for the documentation validator and document the new suite
- provide a minimal EXPECT_THROW macro in the embedded gtest harness

## Testing
- ctest --test-dir build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6366a73b083208df405d7591a6e3d