### PR TITLE
feat: add reusable recording command encoder core

### DIFF
--- a/docs/modules/rendering/QUICKSTART.md
+++ b/docs/modules/rendering/QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ✅ **Research Baseline Preset (RE-610)** - COMPLETE
 🟡 **GPU Resource Provider (T-0120)** - IN PROGRESS (command buffer orchestration live)
-🟡 **Command Encoder (T-0119)** - IN PROGRESS (OpenGL draw recording implemented)
+🟡 **Command Encoder (T-0119)** - IN PROGRESS (backend-agnostic recording provider + OpenGL draw recording implemented)
 
 ## Quick Test
 

--- a/docs/modules/rendering/README.md
+++ b/docs/modules/rendering/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-> **Status:** ⚠️ **Blocked** — GPU resource provider and command encoder work (see [`T-0120`](../../../hybrid_workflow/backlog/T-0120-gpu-resource-provider.md) and [`T-0119`](../../../hybrid_workflow/backlog/T-0119-command-encoder-integration.md)) remain unfinished. OpenGL and Vulkan command encoders now record frame-graph draw/dispatch commands for scheduler inspection, but the backends still rely on the recording provider and cannot allocate GPU buffers, textures, or shaders, so no real draw commands execute yet.
+> **Status:** ⚠️ **Blocked** — GPU resource provider and command encoder work (see [`T-0120`](../../../hybrid_workflow/backlog/T-0120-gpu-resource-provider.md) and [`T-0119`](../../../hybrid_workflow/backlog/T-0119-command-encoder-integration.md)) remain unfinished. A backend-agnostic recording encoder/provider now ships alongside the OpenGL and Vulkan integrations, enabling frame-graph passes to be validated without native command buffers, but the backends still rely on the recording provider and cannot allocate GPU buffers, textures, or shaders, so no real draw commands execute yet.
 
 The rendering module currently provides frame-graph compilation, scheduler prototypes, and resource lifetime tracking, but the missing GPU execution path prevents end-to-end rendering. This README tracks the outstanding work needed to reach functional backends in addition to describing the existing infrastructure.
 

--- a/engine/rendering/CMakeLists.txt
+++ b/engine/rendering/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(${target_name}
         src/backend/opengl/runtime_adapter.cpp
         src/backend/vulkan/command_encoder.cpp
         src/backend/vulkan/resource_provider.cpp
+        src/command_encoder.cpp
         src/command_encoder_tracing.cpp
         src/frame_graph.cpp
         src/forward_pipeline.cpp

--- a/engine/rendering/include/engine/rendering/command_encoder.hpp
+++ b/engine/rendering/include/engine/rendering/command_encoder.hpp
@@ -2,8 +2,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 #include "engine/assets/handles.hpp"
 #include "engine/math/transform.hpp"
@@ -125,5 +127,88 @@ namespace engine::rendering
         /// Finalise encoding for the render pass described by \p descriptor.
         virtual void end_encoder(const CommandEncoderDescriptor& descriptor,
                                  std::unique_ptr<CommandEncoder> encoder) = 0;
+    };
+
+    /**
+     * \brief Concrete command encoder that records draw and dispatch commands in memory.
+     *
+     * The recording encoder is useful for unit tests, diagnostics, and CPU-only execution
+     * paths that need to inspect the commands emitted by render passes without touching a
+     * backend-specific command buffer.
+     */
+    class RecordingCommandEncoder final : public CommandEncoder
+    {
+    public:
+        void draw_geometry(const GeometryDrawCommand& command) override;
+        void dispatch_compute(const ComputeDispatchCommand& command) override;
+
+        /// Remove all previously recorded commands.
+        void clear() noexcept;
+
+        [[nodiscard]] const std::vector<EncodedCommand>& commands() const noexcept
+        {
+            return commands_;
+        }
+
+        [[nodiscard]] const std::vector<GeometryDrawCommand>& geometry_draws() const noexcept
+        {
+            return geometry_draws_;
+        }
+
+        [[nodiscard]] const std::vector<ComputeDispatchCommand>& compute_dispatches() const noexcept
+        {
+            return compute_dispatches_;
+        }
+
+    private:
+        std::vector<EncodedCommand> commands_{};
+        std::vector<GeometryDrawCommand> geometry_draws_{};
+        std::vector<ComputeDispatchCommand> compute_dispatches_{};
+    };
+
+    /**
+     * \brief Provider that hands out \ref RecordingCommandEncoder instances and tracks pass metadata.
+     */
+    class RecordingCommandEncoderProvider final : public CommandEncoderProvider
+    {
+    public:
+        struct DescriptorRecord
+        {
+            std::string pass_name;
+            QueueType queue{QueueType::Graphics};
+            CommandBufferHandle command_buffer{};
+        };
+
+        [[nodiscard]] std::unique_ptr<CommandEncoder> begin_encoder(
+            const CommandEncoderDescriptor& descriptor) override;
+
+        void end_encoder(const CommandEncoderDescriptor& descriptor,
+                         std::unique_ptr<CommandEncoder> encoder) override;
+
+        /// Clear recorded begin/end descriptors and completed encoders.
+        void clear() noexcept;
+
+        [[nodiscard]] const std::vector<DescriptorRecord>& begin_records() const noexcept
+        {
+            return begin_records_;
+        }
+
+        [[nodiscard]] const std::vector<DescriptorRecord>& end_records() const noexcept
+        {
+            return end_records_;
+        }
+
+        [[nodiscard]] const std::vector<std::unique_ptr<RecordingCommandEncoder>>& completed_encoders() const noexcept
+        {
+            return completed_encoders_;
+        }
+
+        /// Transfer ownership of completed encoders to the caller.
+        [[nodiscard]] std::vector<std::unique_ptr<RecordingCommandEncoder>> release_completed_encoders() noexcept;
+
+    private:
+        std::vector<DescriptorRecord> begin_records_{};
+        std::vector<DescriptorRecord> end_records_{};
+        std::vector<std::unique_ptr<RecordingCommandEncoder>> completed_encoders_{};
     };
 }

--- a/engine/rendering/src/command_encoder.cpp
+++ b/engine/rendering/src/command_encoder.cpp
@@ -1,0 +1,68 @@
+#include "engine/rendering/command_encoder.hpp"
+
+#include <iterator>
+#include <memory>
+#include <utility>
+
+namespace engine::rendering
+{
+    void RecordingCommandEncoder::draw_geometry(const GeometryDrawCommand& command)
+    {
+        commands_.push_back(EncodedCommand::make_draw(command));
+        geometry_draws_.push_back(command);
+    }
+
+    void RecordingCommandEncoder::dispatch_compute(const ComputeDispatchCommand& command)
+    {
+        commands_.push_back(EncodedCommand::make_dispatch(command));
+        compute_dispatches_.push_back(command);
+    }
+
+    void RecordingCommandEncoder::clear() noexcept
+    {
+        commands_.clear();
+        geometry_draws_.clear();
+        compute_dispatches_.clear();
+    }
+
+    std::unique_ptr<CommandEncoder> RecordingCommandEncoderProvider::begin_encoder(
+        const CommandEncoderDescriptor& descriptor)
+    {
+        begin_records_.push_back(DescriptorRecord{
+            std::string{descriptor.pass_name}, descriptor.queue, descriptor.command_buffer
+        });
+
+        return std::make_unique<RecordingCommandEncoder>();
+    }
+
+    void RecordingCommandEncoderProvider::end_encoder(const CommandEncoderDescriptor& descriptor,
+                                                      std::unique_ptr<CommandEncoder> encoder)
+    {
+        end_records_.push_back(DescriptorRecord{
+            std::string{descriptor.pass_name}, descriptor.queue, descriptor.command_buffer
+        });
+
+        if (auto* recording = dynamic_cast<RecordingCommandEncoder*>(encoder.get()); recording != nullptr)
+        {
+            static_cast<void>(encoder.release());
+            completed_encoders_.emplace_back(recording);
+        }
+    }
+
+    void RecordingCommandEncoderProvider::clear() noexcept
+    {
+        begin_records_.clear();
+        end_records_.clear();
+        completed_encoders_.clear();
+    }
+
+    std::vector<std::unique_ptr<RecordingCommandEncoder>>
+    RecordingCommandEncoderProvider::release_completed_encoders() noexcept
+    {
+        std::vector<std::unique_ptr<RecordingCommandEncoder>> encoders{};
+        encoders.reserve(completed_encoders_.size());
+        std::move(completed_encoders_.begin(), completed_encoders_.end(), std::back_inserter(encoders));
+        completed_encoders_.clear();
+        return encoders;
+    }
+}

--- a/engine/rendering/tests/CMakeLists.txt
+++ b/engine/rendering/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(ENGINE_RENDERING_TEST_SOURCES
         test_module.cpp
         test_frame_graph.cpp
         test_camera.cpp
+        test_command_encoder.cpp
         test_forward_pipeline.cpp
         test_command_encoder_tracing.cpp
         test_opengl_command_encoder.cpp

--- a/engine/rendering/tests/test_command_encoder.cpp
+++ b/engine/rendering/tests/test_command_encoder.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "engine/assets/handles.hpp"
+#include "engine/rendering/command_encoder.hpp"
+
+namespace
+{
+    using engine::rendering::CommandBufferHandle;
+    using engine::rendering::CommandEncoderDescriptor;
+    using engine::rendering::QueueType;
+}
+
+TEST(RecordingCommandEncoder, RecordsDrawsAndDispatches)
+{
+    engine::rendering::RecordingCommandEncoder encoder;
+
+    engine::rendering::GeometryDrawCommand draw{};
+    draw.geometry = engine::assets::MeshHandle{std::string{"mesh.handle"}};
+    draw.material = engine::assets::MaterialHandle{std::string{"material.handle"}};
+    encoder.draw_geometry(draw);
+
+    engine::rendering::ComputeDispatchCommand dispatch{};
+    dispatch.group_count_x = 4U;
+    dispatch.group_count_y = 2U;
+    dispatch.group_count_z = 1U;
+    encoder.dispatch_compute(dispatch);
+
+    const auto& commands = encoder.commands();
+    ASSERT_EQ(commands.size(), 2U); // NOLINT
+    EXPECT_TRUE(commands.front().is_draw());
+    EXPECT_TRUE(commands.back().is_dispatch());
+
+    const auto& draws = encoder.geometry_draws();
+    ASSERT_EQ(draws.size(), 1U); // NOLINT
+    EXPECT_EQ(std::get<engine::assets::MeshHandle>(draws.front().geometry).id(),
+              std::string{"mesh.handle"});
+    EXPECT_EQ(draws.front().material.id(), std::string{"material.handle"});
+
+    const auto& dispatches = encoder.compute_dispatches();
+    ASSERT_EQ(dispatches.size(), 1U); // NOLINT
+    EXPECT_EQ(dispatches.front().group_count_x, 4U);
+    EXPECT_EQ(dispatches.front().group_count_y, 2U);
+    EXPECT_EQ(dispatches.front().group_count_z, 1U);
+
+    encoder.clear();
+    EXPECT_TRUE(encoder.commands().empty());
+    EXPECT_TRUE(encoder.geometry_draws().empty());
+    EXPECT_TRUE(encoder.compute_dispatches().empty());
+}
+
+TEST(RecordingCommandEncoderProvider, TracksDescriptorsAndEncoders)
+{
+    engine::rendering::RecordingCommandEncoderProvider provider;
+
+    CommandBufferHandle handle{};
+    handle.index = 7U;
+
+    CommandEncoderDescriptor descriptor{"PassName", QueueType::Compute, handle};
+    auto encoder = provider.begin_encoder(descriptor);
+    ASSERT_NE(encoder, nullptr);
+
+    encoder->dispatch_compute(engine::rendering::ComputeDispatchCommand{});
+
+    provider.end_encoder(descriptor, std::move(encoder));
+
+    ASSERT_EQ(provider.begin_records().size(), 1U); // NOLINT
+    EXPECT_EQ(provider.begin_records().front().pass_name, "PassName");
+    EXPECT_EQ(provider.begin_records().front().queue, QueueType::Compute);
+    EXPECT_EQ(provider.begin_records().front().command_buffer.index, handle.index);
+
+    ASSERT_EQ(provider.end_records().size(), 1U); // NOLINT
+    EXPECT_EQ(provider.end_records().front().pass_name, "PassName");
+
+    const auto& completed = provider.completed_encoders();
+    ASSERT_EQ(completed.size(), 1U); // NOLINT
+    ASSERT_EQ(completed.front()->commands().size(), 1U); // NOLINT
+    EXPECT_TRUE(completed.front()->commands().front().is_dispatch());
+
+    auto released = provider.release_completed_encoders();
+    ASSERT_EQ(released.size(), 1U); // NOLINT
+    EXPECT_TRUE(provider.completed_encoders().empty());
+
+    provider.clear();
+    EXPECT_TRUE(provider.begin_records().empty());
+    EXPECT_TRUE(provider.end_records().empty());
+}

--- a/hybrid_workflow/backlog/T-0119-command-encoder-integration.md
+++ b/hybrid_workflow/backlog/T-0119-command-encoder-integration.md
@@ -108,7 +108,10 @@ public:
 
 1. [x] Finalize encoder/provider handshake with T-0120 owners and record decisions in this file.
    - [x] (2025-04-26) Documented the command encoder ↔ resource provider handshake covering frame-graph encoder scopes, scheduler allocation, backend encoder providers, and submission/telemetry translation for diagnostics alignment with T-0120.
-2. [ ] Implement encoder core in `engine/rendering/src/command_encoder.cpp` with unit coverage.
+2. [x] Implement encoder core in `engine/rendering/src/command_encoder.cpp` with unit coverage.
+   - [x] (2025-05-30) Introduced reusable recording encoders and provider infrastructure so frame-graph
+     passes can be validated without backend dependencies, with dedicated unit tests covering
+     command capture and lifecycle bookkeeping.
 3. [x] Wire OpenGL and Vulkan scheduler backends to consume encoded commands.
    - [x] (2025-04-26) Frame-graph execution now finalizes command encoders before GPU submission so backend providers observe a completed recording prior to scheduler hand-off.
    - [x] (2025-05-11) Recycled command buffer handles in `NativeSchedulerBase` so backend providers reuse encoder-backed buffers without unbounded handle growth.
@@ -165,6 +168,10 @@ python scripts/validate_docs.py
 ### Updated Files
 
 - `engine/rendering/include/engine/rendering/command_encoder.hpp`
+- `engine/rendering/src/command_encoder.cpp`
+- `engine/rendering/tests/test_command_encoder.cpp`
+- `engine/rendering/tests/CMakeLists.txt`
+- `engine/rendering/CMakeLists.txt`
 - `engine/rendering/include/engine/rendering/backend/native_scheduler_base.hpp`
 - `engine/rendering/src/backend/opengl/opengl_command_encoder.cpp`
 - `engine/rendering/src/backend/vulkan/vulkan_command_encoder.cpp`
@@ -178,7 +185,7 @@ python scripts/validate_docs.py
 
 ## Completion Checklist (Definition of Done)
 
-- [ ] Encoder APIs implemented with unit coverage.
+- [x] Encoder APIs implemented with unit coverage.
 - [ ] Backend schedulers submit encoded work for OpenGL and Vulkan.
 - [ ] Frame-graph integration tests validate end-to-end rendering.
 - [ ] Runtime/tooling docs updated with encoder usage patterns.


### PR DESCRIPTION
## Summary
- add backend-agnostic recording command encoder/provider implementations with dedicated unit coverage
- refresh rendering documentation and T-0119 backlog notes to capture the new workflow milestone

## Testing
- cmake --preset linux-gcc-debug
- cmake --build --preset linux-gcc-debug
- ctest --preset linux-gcc-debug
- pytest python/tests scripts/tests
- python scripts/validate_docs.py

------
https://chatgpt.com/codex/tasks/task_e_690b52c7e7d08320b66e13f5e08c7d7e