### PR TITLE
Ensure geometry viewer materials and cube UVs are configured

### DIFF
--- a/engine/geometry/src/api.cpp
+++ b/engine/geometry/src/api.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <limits>
 #include <cmath>
+#include <vector>
 
 namespace engine::geometry
 {
@@ -64,18 +65,43 @@ namespace engine::geometry
         }};
 
         // Build mesh from AABB face quads
+        std::vector<math::vec2> texture_coordinates{};
+        texture_coordinates.reserve(face_quads.size() * 4U);
+
+        const math::vec3 extent = box.max - box.min;
+        const math::vec3 safe_extent{
+            std::max(extent[0], std::numeric_limits<float>::epsilon()),
+            std::max(extent[1], std::numeric_limits<float>::epsilon()),
+            std::max(extent[2], std::numeric_limits<float>::epsilon())
+        };
+
+        const std::array<std::pair<int, int>, 6> face_axes{{
+            {2, 1}, // -X: u = z, v = y
+            {2, 1}, // +X
+            {0, 2}, // -Y: u = x, v = z
+            {0, 2}, // +Y
+            {0, 1}, // -Z: u = x, v = y
+            {0, 1}  // +Z
+        }};
+
         for (std::size_t face_idx = 0; face_idx < face_quads.size(); ++face_idx)
         {
             const auto& quad = face_quads[face_idx];
             const auto& normal = face_normals[face_idx];
+            const auto [u_axis, v_axis] = face_axes[face_idx];
 
             const std::uint32_t base_vertex = static_cast<std::uint32_t>(mesh.rest_positions.size());
 
             // Add 4 vertices for this face
             for (int i = 0; i < 4; ++i)
             {
-                mesh.rest_positions.push_back(corners[quad[i]]);
+                const auto position = corners[quad[i]];
+                mesh.rest_positions.push_back(position);
                 mesh.normals.push_back(normal);
+
+                const float u = (position[u_axis] - box.min[u_axis]) / safe_extent[u_axis];
+                const float v = (position[v_axis] - box.min[v_axis]) / safe_extent[v_axis];
+                texture_coordinates.emplace_back(u, v);
             }
 
             // Add 2 triangles (quad = 2 tris)
@@ -89,13 +115,7 @@ namespace engine::geometry
         }
 
         mesh.positions = mesh.rest_positions;
-
-        // Simple UV coordinates
-        mesh.texture_coordinates.resize(mesh.positions.size());
-        for (std::size_t i = 0; i < mesh.texture_coordinates.size(); ++i)
-        {
-            mesh.texture_coordinates[i] = math::vec2{0.5F, 0.5F};
-        }
+        mesh.texture_coordinates = std::move(texture_coordinates);
 
         update_bounds(mesh);
         return mesh;

--- a/engine/geometry/tests/test_shapes.cpp
+++ b/engine/geometry/tests/test_shapes.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <numbers>
 
+#include "engine/geometry/api.hpp"
 #include "engine/geometry/shapes.hpp"
 #include "engine/math/quaternion.hpp"
 #include "engine/math/utils/utils.hpp"
@@ -882,4 +884,44 @@ TEST(CylinderGeometry, EdgeCaseZeroHeight)
 
     const double dist_sq = SquaredDistance(cylinder, above);
     EXPECT_EQ(dist_sq, 9.0); // z-distance squared
+}
+
+TEST(SurfaceMesh, UnitCubeProvidesPerFaceTextureCoordinates)
+{
+    const auto cube = engine::geometry::make_unit_cube();
+    ASSERT_EQ(cube.positions.size(), 24U);
+    ASSERT_EQ(cube.indices.size(), 36U);
+    ASSERT_EQ(cube.normals.size(), cube.positions.size());
+    ASSERT_EQ(cube.texture_coordinates.size(), cube.positions.size());
+
+    const std::array<engine::math::vec2, 4> expected_uvs{
+        engine::math::vec2{0.0f, 0.0f},
+        engine::math::vec2{1.0f, 0.0f},
+        engine::math::vec2{1.0f, 1.0f},
+        engine::math::vec2{0.0f, 1.0f},
+    };
+
+    const std::size_t face_count = cube.texture_coordinates.size() / 4U;
+    for (std::size_t face = 0; face < face_count; ++face)
+    {
+        std::array<engine::math::vec2, 4> face_uvs{};
+        for (std::size_t corner = 0; corner < 4; ++corner)
+        {
+            const auto& uv = cube.texture_coordinates[face * 4U + corner];
+            EXPECT_GE(uv[0], 0.0f);
+            EXPECT_LE(uv[0], 1.0f);
+            EXPECT_GE(uv[1], 0.0f);
+            EXPECT_LE(uv[1], 1.0f);
+            face_uvs[corner] = uv;
+        }
+
+        for (const auto& expected : expected_uvs)
+        {
+            const bool found = std::any_of(face_uvs.begin(), face_uvs.end(), [&](const engine::math::vec2& actual) {
+                return std::fabs(actual[0] - expected[0]) < 1e-4f
+                    && std::fabs(actual[1] - expected[1]) < 1e-4f;
+            });
+            EXPECT_TRUE(found);
+        }
+    }
 }

--- a/engine/tools/examples/geometry_viewer.cpp
+++ b/engine/tools/examples/geometry_viewer.cpp
@@ -20,6 +20,7 @@
 
 #include <entt/entity/entity.hpp>
 
+#include "engine/assets/handles.hpp"
 #include "engine/assets/mesh_asset.hpp"
 #include "engine/assets/point_cloud_asset.hpp"
 #include "engine/assets/validation.hpp"
@@ -251,6 +252,7 @@ namespace
             options.height = WINDOW_HEIGHT;
             baseline_resources_ = engine::rendering::configure_research_baseline(backend_->frame_graph(), options);
             backend_->frame_graph().compile();
+            register_default_material();
 #endif
         }
 
@@ -259,6 +261,14 @@ namespace
 #if ENGINE_ENABLE_RENDERING
             auto cube_mesh = engine::geometry::make_unit_cube();
             mesh_storage_->store(std::string{kProceduralCubeId}, std::move(cube_mesh));
+
+#    if ENGINE_ENABLE_ASSETS
+            material_validator_registration_ =
+                engine::assets::HandleValidatorRegistry::instance().register_material_validator(
+                    [handle = default_material_](const engine::assets::MaterialHandle& candidate) {
+                        return !candidate.empty() && candidate.id() == handle.id();
+                    });
+#    endif
 
 #    if ENGINE_ENABLE_ASSETS
             mesh_validator_registration_ =
@@ -279,7 +289,7 @@ namespace
 #if ENGINE_ENABLE_RENDERING && ENGINE_ENABLE_ASSETS
             attach_render_geometry(std::string{kProceduralCubeId},
                 engine::rendering::components::RenderGeometry::from_mesh(
-                    engine::assets::MeshHandle{std::string{kProceduralCubeId}}));
+                    engine::assets::MeshHandle{std::string{kProceduralCubeId}}, default_material_));
 #endif
         }
 
@@ -368,7 +378,8 @@ namespace
                 auto surface_mesh = engine::geometry::mesh::build_surface_mesh_from_halfedge(asset.mesh.interface);
                 focus_camera_on_bounds(surface_mesh.bounds);
                 attach_render_geometry(std::string{asset.descriptor.handle.id()},
-                    engine::rendering::components::RenderGeometry::from_mesh(asset.descriptor.handle));
+                    engine::rendering::components::RenderGeometry::from_mesh(
+                        asset.descriptor.handle, default_material_));
                 ENGINE_INFO("Loaded mesh '{}'", path.string());
             }
             catch (const std::exception& ex)
@@ -392,7 +403,8 @@ namespace
                 const auto positions = asset.point_cloud.interface.positions();
                 focus_camera_on_bounds(engine::geometry::BoundingAabb(positions));
                 attach_render_geometry(std::string{asset.descriptor.handle.id()},
-                    engine::rendering::components::RenderGeometry::from_point_cloud(asset.descriptor.handle));
+                    engine::rendering::components::RenderGeometry::from_point_cloud(
+                        asset.descriptor.handle, default_material_));
                 ENGINE_INFO("Loaded point cloud '{}'", path.string());
             }
             catch (const std::exception& ex)
@@ -433,6 +445,19 @@ namespace
 #else
             (void)identifier;
             (void)geometry;
+#endif
+        }
+
+        void register_default_material()
+        {
+#if ENGINE_ENABLE_RENDERING
+            if (!backend_)
+            {
+                return;
+            }
+
+            backend_->material_system().register_material(
+                engine::rendering::MaterialSystem::MaterialRecord{default_material_, {}});
 #endif
         }
 
@@ -528,6 +553,7 @@ namespace
 
         std::shared_ptr<ProceduralMeshStorage> mesh_storage_{std::make_shared<ProceduralMeshStorage>()};
         std::shared_ptr<void> mesh_validator_registration_{};
+        std::shared_ptr<void> material_validator_registration_{};
 #if ENGINE_ENABLE_ASSETS
         engine::assets::MeshCache mesh_cache_{};
         engine::assets::PointCloudCache point_cloud_cache_{};
@@ -538,6 +564,7 @@ namespace
         entt::entity camera_entity_{entt::null};
 #endif
         std::unordered_map<std::string, entt::entity> render_entities_{};
+        engine::assets::MaterialHandle default_material_{std::string{"geometry_viewer.material.default"}};
         float camera_yaw_{0.0f};
         float camera_pitch_{0.3f};
         float camera_radius_{CAMERA_DISTANCE};


### PR DESCRIPTION
## Summary
- generate per-face UV coordinates for the unit cube mesh and cover it with a regression test
- register and reuse a default material handle in the geometry viewer so procedural and streamed assets participate in the material system

## Testing
- cmake --preset linux-gcc-debug *(fails: GLFW/Xrandr dependencies and reused binary directory in upstream build configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c18844f883208777d2fbae239800)