### PR TITLE
Add wireframe graph rendering support

### DIFF
--- a/docs/examples/GEOMETRY_VIEWER_COMPLETION_GUIDE.md
+++ b/docs/examples/GEOMETRY_VIEWER_COMPLETION_GUIDE.md
@@ -31,6 +31,10 @@ Press `G` once the scene is running to open the Geometry Viewer menu, pick which
 
 Left-click without dragging to run the shared selection pipeline: the `SelectionEngine` computes a hit using bounding-box picking, synchronizes the scene hierarchy panel, and surfaces the hit position/distance in the Selection Inspector (enable it under **Widgets → Selection Inspector**).【F:engine/tools/examples/geometry_viewer.cpp†L672-L748】【F:engine/tools/examples/geometry_viewer.cpp†L1080-L1265】
 
+### Wireframe overlay mode
+
+Tap `F` to toggle a wireframe pass that draws every mesh as a graph overlay. The viewer builds a persistent `GraphHandle` for each mesh, caches the line-list graph derived from the surface topology, and attaches the overlay entity whenever wireframe mode is enabled so selection bounds and transforms stay in sync with the base renderable.【F:engine/tools/examples/geometry_viewer.cpp†L681-L820】【F:engine/tools/examples/geometry_viewer.cpp†L988-L1107】 The overlay is also wired into asset lifecycle hooks: new meshes cache graphs as they stream in, while deleted models or the procedural cube automatically drop their overlays so the render graph never references stale handles.【F:engine/tools/examples/geometry_viewer.cpp†L562-L617】【F:engine/tools/examples/geometry_viewer.cpp†L1024-L1107】
+
 If either dependency is missing, the viewer logs a warning and disables OpenGL while keeping the rest of the runtime (input, asset loading, diagnostics) alive so workflow tests can still execute.【F:engine/tools/examples/geometry_viewer.cpp†L61-L109】【F:engine/tools/examples/geometry_viewer.cpp†L265-L283】
 
 ## 3. Bringing Up Rendering Locally

--- a/docs/modules/rendering/README.md
+++ b/docs/modules/rendering/README.md
@@ -148,6 +148,12 @@ Geometry Viewer exposes the config through its Selection Inspector panel so PM-5
 treatments, gradient modes, quality, and the active strategy (auto or explicit). Because the renderer centralises presets, tools
 and runtime passes automatically inherit upgrades as more strategies land.
 
+### Graph and wireframe resources
+
+`OpenGLRenderResourceProvider` now mirrors the mesh/point-cloud path for graphs by accepting a `GraphResolver`, caching uploaded
+edge lists, and exposing `GraphRecord`s to passes that consume `GraphHandle`s. The presentation backend forwards the resolver
+through its constructor so applications can stream analytic graphs or mesh-derived wireframes without recompiling the backend.【F:engine/rendering/include/engine/rendering/backend/opengl/render_resource_provider.hpp†L34-L148】【F:engine/rendering/include/engine/rendering/backend/opengl/presentation_backend.hpp†L33-L69】 Geometry Viewer exercises this path by caching a graph for every mesh and instantiating graph-backed `RenderGeometry` entities whenever the wireframe overlay is enabled, giving research scenes a hotkey (`F`) for edge-only visualization that stays synchronized with transform hierarchies.【F:engine/tools/examples/geometry_viewer.cpp†L562-L820】【F:engine/tools/examples/geometry_viewer.cpp†L988-L1107】
+
 ### Resource Barriers
 
 The frame graph automatically inserts barriers:

--- a/engine/geometry/CMakeLists.txt
+++ b/engine/geometry/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(${target_name}
         src/mesh/halfedge_mesh.cpp
         src/mesh/surface_mesh.cpp
         src/mesh/surface_mesh_conversion.cpp
+        src/mesh/wireframe_graph.cpp
         src/topology/surface_curvature.cpp
         src/topology/surface_topology.cpp
         src/point_cloud/point_cloud.cpp

--- a/engine/geometry/include/engine/geometry/mesh/wireframe_graph.hpp
+++ b/engine/geometry/include/engine/geometry/mesh/wireframe_graph.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "engine/geometry/api.hpp"
+#include "engine/geometry/graph/graph.hpp"
+#include "engine/geometry/mesh/surface_mesh.hpp"
+
+namespace engine::geometry::mesh
+{
+    /**
+     * \brief Build a graph representation capturing the wireframe of a surface mesh.
+     *
+     * The resulting graph contains one vertex per mesh vertex and an undirected
+     * edge for every unique indexed edge in the source mesh. Degenerate edges
+     * and duplicate index pairs are ignored.
+     */
+    [[nodiscard]] ENGINE_GEOMETRY_API geometry::Graph build_wireframe_graph(const SurfaceMesh& surface);
+}

--- a/engine/geometry/src/mesh/wireframe_graph.cpp
+++ b/engine/geometry/src/mesh/wireframe_graph.cpp
@@ -1,0 +1,81 @@
+#include "engine/geometry/mesh/wireframe_graph.hpp"
+
+#include <unordered_set>
+
+namespace engine::geometry::mesh
+{
+    namespace
+    {
+        [[nodiscard]] std::uint64_t make_edge_key(std::uint32_t a, std::uint32_t b) noexcept
+        {
+            if (a > b)
+            {
+                std::swap(a, b);
+            }
+            return (static_cast<std::uint64_t>(a) << 32U) | static_cast<std::uint64_t>(b);
+        }
+    } // namespace
+
+    geometry::Graph build_wireframe_graph(const SurfaceMesh& surface)
+    {
+        geometry::Graph graph;
+        auto& interface = graph.interface;
+
+        if (surface.positions.empty())
+        {
+            return graph;
+        }
+
+        interface.reserve(surface.positions.size(), surface.indices.size());
+
+        std::vector<VertexHandle> vertex_handles;
+        vertex_handles.reserve(surface.positions.size());
+        for (const auto& position : surface.positions)
+        {
+            vertex_handles.push_back(interface.add_vertex(position));
+        }
+
+        if (surface.indices.empty())
+        {
+            return graph;
+        }
+
+        std::unordered_set<std::uint64_t> inserted_edges;
+        inserted_edges.reserve(surface.indices.size());
+
+        const auto add_edge = [&](std::uint32_t lhs, std::uint32_t rhs)
+        {
+            if (lhs >= vertex_handles.size() || rhs >= vertex_handles.size() || lhs == rhs)
+            {
+                return;
+            }
+
+            const auto key = make_edge_key(lhs, rhs);
+            if (inserted_edges.find(key) != inserted_edges.end())
+            {
+                return;
+            }
+            inserted_edges.insert(key);
+
+            const auto existing = interface.find_edge(vertex_handles[lhs], vertex_handles[rhs]);
+            if (existing.has_value())
+            {
+                return;
+            }
+
+            static_cast<void>(interface.add_edge(vertex_handles[lhs], vertex_handles[rhs]));
+        };
+
+        for (std::size_t index = 0; index + 2 < surface.indices.size(); index += 3)
+        {
+            const std::uint32_t a = surface.indices[index];
+            const std::uint32_t b = surface.indices[index + 1];
+            const std::uint32_t c = surface.indices[index + 2];
+            add_edge(a, b);
+            add_edge(b, c);
+            add_edge(c, a);
+        }
+
+        return graph;
+    }
+}

--- a/engine/geometry/tests/CMakeLists.txt
+++ b/engine/geometry/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(engine_geometry_tests
         test_graph_io.cpp
         test_surface_mesh_conversion.cpp
         test_surface_mesh_io.cpp
+        test_wireframe_graph.cpp
         test_surface_curvature.cpp
         test_surface_topology.cpp
         test_point_cloud.cpp

--- a/engine/geometry/tests/test_wireframe_graph.cpp
+++ b/engine/geometry/tests/test_wireframe_graph.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include "engine/geometry/mesh/wireframe_graph.hpp"
+#include "engine/geometry/mesh/surface_mesh.hpp"
+
+namespace
+{
+    using engine::geometry::SurfaceMesh;
+    using engine::geometry::Graph;
+}
+
+TEST(WireframeGraph, BuildsEdgesFromTriangleMesh)
+{
+    SurfaceMesh mesh;
+    mesh.positions = {
+        {0.0F, 0.0F, 0.0F},
+        {1.0F, 0.0F, 0.0F},
+        {0.0F, 1.0F, 0.0F},
+        {0.0F, 0.0F, 1.0F},
+    };
+    mesh.indices = {
+        0U, 1U, 2U,
+        0U, 2U, 3U,
+    };
+
+    const Graph graph = engine::geometry::mesh::build_wireframe_graph(mesh);
+    const auto& interface = graph.interface;
+
+    EXPECT_EQ(interface.vertex_count(), 4U);
+    // Triangles should produce 5 unique edges
+    EXPECT_EQ(interface.edge_count(), 5U);
+}
+
+TEST(WireframeGraph, IgnoresDegenerateIndices)
+{
+    SurfaceMesh mesh;
+    mesh.positions = {
+        {0.0F, 0.0F, 0.0F},
+        {1.0F, 0.0F, 0.0F},
+    };
+    mesh.indices = {0U, 0U, 1U, 1U, 1U, 0U};
+
+    const Graph graph = engine::geometry::mesh::build_wireframe_graph(mesh);
+    const auto& interface = graph.interface;
+
+    // Only one valid edge (0,1)
+    EXPECT_EQ(interface.edge_count(), 1U);
+}

--- a/engine/rendering/include/engine/rendering/backend/opengl/immediate_command_stream.hpp
+++ b/engine/rendering/include/engine/rendering/backend/opengl/immediate_command_stream.hpp
@@ -77,6 +77,7 @@ namespace engine::rendering::backend::opengl
         void execute_draw_command(const GeometryDrawCommand& command);
         void execute_mesh_draw(const GeometryDrawCommand& command);
         void execute_point_cloud_draw(const GeometryDrawCommand& command);
+        void execute_graph_draw(const GeometryDrawCommand& command);
         void execute_compute_dispatch(const ComputeDispatchCommand& command);
         bool ensure_shader_program();
         unsigned int compile_shader(unsigned int type, const char* source);

--- a/engine/rendering/include/engine/rendering/backend/opengl/presentation_backend.hpp
+++ b/engine/rendering/include/engine/rendering/backend/opengl/presentation_backend.hpp
@@ -37,11 +37,13 @@ namespace engine::rendering::backend::opengl
 
         using MeshResolver = OpenGLRenderResourceProvider::MeshResolver;
         using PointCloudResolver = OpenGLRenderResourceProvider::PointCloudResolver;
+        using GraphResolver = OpenGLRenderResourceProvider::GraphResolver;
 
         explicit OpenGLPresentationBackend(MeshResolver mesh_resolver,
                                            PointCloudResolver point_cloud_resolver = {},
                                            std::unique_ptr<ForwardPipeline> pipeline = nullptr,
-                                           std::uint64_t retention_frames = 0);
+                                           std::uint64_t retention_frames = 0,
+                                           GraphResolver graph_resolver = {});
         ~OpenGLPresentationBackend() noexcept;
 
         [[nodiscard]] MaterialSystem& material_system() noexcept { return materials_; }

--- a/engine/rendering/include/engine/rendering/backend/opengl/render_resource_provider.hpp
+++ b/engine/rendering/include/engine/rendering/backend/opengl/render_resource_provider.hpp
@@ -11,6 +11,7 @@
 
 #include "engine/assets/handles.hpp"
 #include "engine/geometry/api.hpp"
+#include "engine/geometry/graph/graph.hpp"
 #include "engine/geometry/point_cloud/point_cloud.hpp"
 #include "engine/math/vector.hpp"
 #include "engine/rendering/render_pass.hpp"
@@ -33,6 +34,8 @@ namespace engine::rendering::backend::opengl
             const assets::MeshHandle& handle)>;
         using PointCloudResolver = std::function<std::optional<geometry::PointCloud>(
             const assets::PointCloudHandle& handle)>;
+        using GraphResolver = std::function<std::optional<geometry::Graph>(
+            const assets::GraphHandle& handle)>;
 
         struct MeshRecord
         {
@@ -55,7 +58,8 @@ namespace engine::rendering::backend::opengl
         };
 
         explicit OpenGLRenderResourceProvider(MeshResolver mesh_resolver,
-                                              PointCloudResolver point_cloud_resolver = {});
+                                              PointCloudResolver point_cloud_resolver = {},
+                                              GraphResolver graph_resolver = {});
         ~OpenGLRenderResourceProvider() override;
 
         void require_mesh(const assets::MeshHandle& handle) override;
@@ -90,11 +94,30 @@ namespace engine::rendering::backend::opengl
         point_cloud(const assets::PointCloudHandle& handle) const noexcept;
         [[nodiscard]] std::size_t loaded_point_cloud_count() const noexcept;
 
+        struct GraphRecord
+        {
+            assets::GraphHandle handle{};
+            std::vector<math::vec3> positions;
+            std::vector<std::uint32_t> indices;
+            geometry::Aabb bounds{};
+#if ENGINE_RENDERING_HAS_GLAD
+            unsigned int vertex_array{0};
+            unsigned int position_buffer{0};
+            unsigned int index_buffer{0};
+            bool gpu_uploaded{false};
+#else
+            bool gpu_uploaded{false};
+#endif
+        };
+
+        [[nodiscard]] const GraphRecord* graph(const assets::GraphHandle& handle) const noexcept;
+
     private:
         MeshResolver mesh_resolver_;
         PointCloudResolver point_cloud_resolver_;
+        GraphResolver graph_resolver_;
         std::unordered_map<std::string, MeshRecord> meshes_{};
-        std::unordered_set<std::string> graphs_{};
+        std::unordered_map<std::string, GraphRecord> graphs_{};
         std::unordered_map<std::string, PointCloudRecord> point_clouds_{};
         std::unordered_set<std::string> materials_{};
         std::unordered_set<std::string> shaders_{};
@@ -114,5 +137,9 @@ namespace engine::rendering::backend::opengl
         static geometry::PointCloud prepare_point_cloud(geometry::PointCloud cloud);
         void upload_point_cloud_to_gpu(PointCloudRecord& record);
         static void destroy_point_cloud_gpu_resources(PointCloudRecord& record) noexcept;
+        void ensure_graph_loaded(const assets::GraphHandle& handle);
+        static geometry::Graph prepare_graph(geometry::Graph graph);
+        void upload_graph_to_gpu(GraphRecord& record);
+        static void destroy_graph_gpu_resources(GraphRecord& record) noexcept;
     };
 }

--- a/engine/rendering/include/engine/rendering/backend/opengl/runtime_adapter.hpp
+++ b/engine/rendering/include/engine/rendering/backend/opengl/runtime_adapter.hpp
@@ -26,10 +26,12 @@ namespace engine::rendering::backend::opengl
     public:
         using MeshResolver = OpenGLRenderResourceProvider::MeshResolver;
         using PointCloudResolver = OpenGLRenderResourceProvider::PointCloudResolver;
+        using GraphResolver = OpenGLRenderResourceProvider::GraphResolver;
 
         explicit OpenGLRuntimeSubmission(MeshResolver mesh_resolver,
                                          PointCloudResolver point_cloud_resolver = {},
-                                         std::uint64_t retention_frames = 0);
+                                         std::uint64_t retention_frames = 0,
+                                         GraphResolver graph_resolver = {});
 
         void set_retention_frames(std::uint64_t frames) noexcept;
         [[nodiscard]] std::uint64_t retention_frames() const noexcept;

--- a/engine/rendering/src/backend/opengl/immediate_command_stream.cpp
+++ b/engine/rendering/src/backend/opengl/immediate_command_stream.cpp
@@ -198,6 +198,13 @@ namespace engine::rendering::backend::opengl
                     execute_mesh_draw(command);
                 }
             }
+            else if constexpr (std::is_same_v<Handle, assets::GraphHandle>)
+            {
+                if (!geometry_handle.empty())
+                {
+                    execute_graph_draw(command);
+                }
+            }
             else if constexpr (std::is_same_v<Handle, assets::PointCloudHandle>)
             {
                 if (!geometry_handle.empty())
@@ -256,6 +263,62 @@ namespace engine::rendering::backend::opengl
         {
             const auto vertex_count = static_cast<GLsizei>(record->positions.size());
             glad_glDrawArrays(GL_TRIANGLES, 0, vertex_count);
+        }
+
+        if (glad_glBindVertexArray != nullptr)
+        {
+            glad_glBindVertexArray(0);
+        }
+#else
+        static_cast<void>(command);
+#endif
+    }
+
+    void OpenGLImmediateCommandStream::execute_graph_draw(const GeometryDrawCommand& command)
+    {
+        if (render_resources_ == nullptr)
+        {
+            return;
+        }
+
+        const auto handle = std::get<assets::GraphHandle>(command.geometry);
+        render_resources_->require_graph(handle);
+
+        const auto* record = render_resources_->graph(handle);
+        if (record == nullptr)
+        {
+            return;
+        }
+
+        ++draw_calls_;
+
+#if ENGINE_RENDERING_HAS_GLAD
+        if (!ensure_shader_program())
+        {
+            return;
+        }
+
+        upload_draw_uniforms(command, false);
+
+        if (record->vertex_array != 0U && glad_glBindVertexArray != nullptr)
+        {
+            glad_glBindVertexArray(record->vertex_array);
+        }
+
+        if (!record->indices.empty() && record->index_buffer != 0U && glad_glDrawElements != nullptr)
+        {
+            if (glad_glLineWidth != nullptr)
+            {
+                glad_glLineWidth(1.5F);
+            }
+            glad_glDrawElements(GL_LINES,
+                                static_cast<GLsizei>(record->indices.size()),
+                                GL_UNSIGNED_INT,
+                                nullptr);
+        }
+        else if (!record->positions.empty() && glad_glDrawArrays != nullptr)
+        {
+            glad_glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(record->positions.size()));
         }
 
         if (glad_glBindVertexArray != nullptr)

--- a/engine/rendering/src/backend/opengl/presentation_backend.cpp
+++ b/engine/rendering/src/backend/opengl/presentation_backend.cpp
@@ -37,8 +37,12 @@ namespace engine::rendering::backend::opengl
     OpenGLPresentationBackend::OpenGLPresentationBackend(MeshResolver mesh_resolver,
                                                          PointCloudResolver point_cloud_resolver,
                                                          std::unique_ptr<ForwardPipeline> pipeline,
-                                                         std::uint64_t retention_frames)
-        : submission_(std::move(mesh_resolver), std::move(point_cloud_resolver), retention_frames)
+                                                         std::uint64_t retention_frames,
+                                                         GraphResolver graph_resolver)
+        : submission_(std::move(mesh_resolver),
+                      std::move(point_cloud_resolver),
+                      retention_frames,
+                      std::move(graph_resolver))
         , pipeline_(std::move(pipeline))
     {
     }

--- a/engine/rendering/src/backend/opengl/render_resource_provider.cpp
+++ b/engine/rendering/src/backend/opengl/render_resource_provider.cpp
@@ -10,9 +10,10 @@
 #    include <glad/gl.h>
 #endif
 
-#include "engine/geometry/api.hpp"
 #include "engine/core/log.hpp"
 #include "engine/core/threading/io_thread_pool.hpp"
+#include "engine/geometry/api.hpp"
+#include "engine/geometry/shapes/aabb.hpp"
 #include "engine/geometry/point_cloud/point_cloud.hpp"
 
 namespace engine::rendering::backend::opengl
@@ -176,9 +177,11 @@ namespace engine::rendering::backend::opengl
     };
 
     OpenGLRenderResourceProvider::OpenGLRenderResourceProvider(MeshResolver mesh_resolver,
-                                                               PointCloudResolver point_cloud_resolver)
+                                                               PointCloudResolver point_cloud_resolver,
+                                                               GraphResolver graph_resolver)
         : mesh_resolver_(std::move(mesh_resolver))
         , point_cloud_resolver_(std::move(point_cloud_resolver))
+        , graph_resolver_(std::move(graph_resolver))
         , async_mesh_loader_(std::make_unique<AsyncMeshLoader>())
     {
         if (!mesh_resolver_)
@@ -198,6 +201,11 @@ namespace engine::rendering::backend::opengl
         for (auto& [_, record] : point_clouds_)
         {
             destroy_point_cloud_gpu_resources(record);
+        }
+
+        for (auto& [_, record] : graphs_)
+        {
+            destroy_graph_gpu_resources(record);
         }
     }
 
@@ -255,7 +263,11 @@ namespace engine::rendering::backend::opengl
 
     void OpenGLRenderResourceProvider::require_graph(const assets::GraphHandle& handle)
     {
-        record_handle(graphs_, handle);
+        if (handle.empty())
+        {
+            return;
+        }
+        ensure_graph_loaded(handle);
     }
 
     void OpenGLRenderResourceProvider::require_point_cloud(const assets::PointCloudHandle& handle)
@@ -377,6 +389,25 @@ namespace engine::rendering::backend::opengl
     std::size_t OpenGLRenderResourceProvider::loaded_point_cloud_count() const noexcept
     {
         return point_clouds_.size();
+    }
+
+    const OpenGLRenderResourceProvider::GraphRecord*
+    OpenGLRenderResourceProvider::graph(const assets::GraphHandle& handle) const noexcept
+    {
+        if (handle.empty())
+        {
+            return nullptr;
+        }
+        const auto& id = handle.id();
+        if (identifier_empty(id))
+        {
+            return nullptr;
+        }
+        if (const auto it = graphs_.find(id); it != graphs_.end())
+        {
+            return &it->second;
+        }
+        return nullptr;
     }
 
     bool OpenGLRenderResourceProvider::schedule_mesh_async(const assets::MeshHandle& handle)
@@ -678,4 +709,133 @@ namespace engine::rendering::backend::opengl
 #endif
         record.gpu_uploaded = false;
     }
-}
+
+    void OpenGLRenderResourceProvider::ensure_graph_loaded(const assets::GraphHandle& handle)
+    {
+        const auto& id = handle.id();
+        if (identifier_empty(id))
+        {
+            throw std::invalid_argument("Graph handle identifier cannot be empty");
+        }
+
+        if (graphs_.find(id) != graphs_.end())
+        {
+            return;
+        }
+
+        if (!graph_resolver_)
+        {
+            throw std::runtime_error("OpenGLRenderResourceProvider requires a graph resolver to load graphs");
+        }
+
+        auto resolved = graph_resolver_(handle);
+        if (!resolved.has_value())
+        {
+            throw std::runtime_error("OpenGLRenderResourceProvider could not resolve graph: " + id);
+        }
+
+        geometry::Graph graph = prepare_graph(std::move(*resolved));
+
+        GraphRecord record{};
+        record.handle = handle;
+        const auto positions = graph.interface.positions();
+        record.positions.assign(positions.begin(), positions.end());
+        if (!record.positions.empty())
+        {
+            record.bounds = geometry::BoundingAabb(std::span{record.positions});
+        }
+
+        record.indices.reserve(graph.interface.edge_count() * 2U);
+        for (auto edge : graph.interface.edges())
+        {
+            if (graph.interface.is_deleted(edge))
+            {
+                continue;
+            }
+            const auto v0 = graph.interface.vertex(edge, 0);
+            const auto v1 = graph.interface.vertex(edge, 1);
+            if (!graph.interface.is_valid(v0) || !graph.interface.is_valid(v1))
+            {
+                continue;
+            }
+            record.indices.push_back(static_cast<std::uint32_t>(v0.index()));
+            record.indices.push_back(static_cast<std::uint32_t>(v1.index()));
+        }
+
+        upload_graph_to_gpu(record);
+        graphs_.insert_or_assign(id, std::move(record));
+    }
+
+    geometry::Graph OpenGLRenderResourceProvider::prepare_graph(geometry::Graph graph)
+    {
+        return graph;
+    }
+
+    void OpenGLRenderResourceProvider::upload_graph_to_gpu(GraphRecord& record)
+    {
+#if ENGINE_RENDERING_HAS_GLAD
+        const bool has_gl = glad_glGenVertexArrays != nullptr && glad_glBindVertexArray != nullptr
+            && glad_glGenBuffers != nullptr && glad_glBindBuffer != nullptr
+            && glad_glBufferData != nullptr && glad_glEnableVertexAttribArray != nullptr
+            && glad_glVertexAttribPointer != nullptr;
+
+        if (!has_gl || record.positions.empty())
+        {
+            return;
+        }
+
+        glad_glGenVertexArrays(1, &record.vertex_array);
+        glad_glBindVertexArray(record.vertex_array);
+
+        glad_glGenBuffers(1, &record.position_buffer);
+        glad_glBindBuffer(GL_ARRAY_BUFFER, record.position_buffer);
+        glad_glBufferData(GL_ARRAY_BUFFER,
+                          static_cast<GLsizeiptr>(record.positions.size() * sizeof(math::vec3)),
+                          reinterpret_cast<const void*>(record.positions.data()),
+                          GL_STATIC_DRAW);
+        glad_glEnableVertexAttribArray(0);
+        glad_glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(math::vec3), nullptr);
+
+        if (!record.indices.empty())
+        {
+            glad_glGenBuffers(1, &record.index_buffer);
+            glad_glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, record.index_buffer);
+            glad_glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+                              static_cast<GLsizeiptr>(record.indices.size() * sizeof(std::uint32_t)),
+                              reinterpret_cast<const void*>(record.indices.data()),
+                              GL_STATIC_DRAW);
+        }
+
+        glad_glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glad_glBindVertexArray(0);
+
+        record.gpu_uploaded = true;
+#else
+        static_cast<void>(record);
+#endif
+    }
+
+    void OpenGLRenderResourceProvider::destroy_graph_gpu_resources(GraphRecord& record) noexcept
+    {
+#if ENGINE_RENDERING_HAS_GLAD
+        if (record.index_buffer != 0U && glad_glDeleteBuffers != nullptr)
+        {
+            glad_glDeleteBuffers(1, &record.index_buffer);
+            record.index_buffer = 0U;
+        }
+        if (record.position_buffer != 0U && glad_glDeleteBuffers != nullptr)
+        {
+            glad_glDeleteBuffers(1, &record.position_buffer);
+            record.position_buffer = 0U;
+        }
+        if (record.vertex_array != 0U && glad_glDeleteVertexArrays != nullptr)
+        {
+            glad_glDeleteVertexArrays(1, &record.vertex_array);
+            record.vertex_array = 0U;
+        }
+#else
+        static_cast<void>(record);
+#endif
+        record.gpu_uploaded = false;
+    }
+} // namespace engine::rendering::backend::opengl

--- a/engine/rendering/src/backend/opengl/runtime_adapter.cpp
+++ b/engine/rendering/src/backend/opengl/runtime_adapter.cpp
@@ -6,8 +6,11 @@ namespace engine::rendering::backend::opengl
 {
     OpenGLRuntimeSubmission::OpenGLRuntimeSubmission(MeshResolver mesh_resolver,
                                                      PointCloudResolver point_cloud_resolver,
-                                                     std::uint64_t retention_frames)
-        : render_resources(std::move(mesh_resolver), std::move(point_cloud_resolver))
+                                                     std::uint64_t retention_frames,
+                                                     GraphResolver graph_resolver)
+        : render_resources(std::move(mesh_resolver),
+                           std::move(point_cloud_resolver),
+                           std::move(graph_resolver))
         , command_stream(render_resources)
         , device_resources(retention_frames)
         , command_encoders(device_resources)

--- a/engine/rendering/tests/test_opengl_render_resource_provider.cpp
+++ b/engine/rendering/tests/test_opengl_render_resource_provider.cpp
@@ -8,11 +8,14 @@
 #include "engine/core/threading/io_thread_pool.hpp"
 
 #include "engine/geometry/api.hpp"
+#include "engine/geometry/graph/graph.hpp"
 
 namespace
 {
     using Provider = engine::rendering::backend::opengl::OpenGLRenderResourceProvider;
+    using engine::assets::GraphHandle;
     using engine::assets::MeshHandle;
+    using engine::geometry::Graph;
     using engine::geometry::SurfaceMesh;
     using engine::math::vec2;
     using engine::math::vec3;
@@ -146,4 +149,77 @@ TEST(OpenGLRenderResourceProvider, AsyncMeshUploadFlushesSuccessfully)
     EXPECT_EQ(provider.pending_async_uploads(), 0U);
 
     IoThreadPool::instance().shutdown();
+}
+
+TEST(OpenGLRenderResourceProvider, LoadsGraphUsingResolver)
+{
+    bool resolver_called = false;
+    auto mesh_resolver = [](const MeshHandle&) -> std::optional<SurfaceMesh> { return std::nullopt; };
+    auto graph_resolver = [&](const GraphHandle& handle) -> std::optional<Graph>
+    {
+        resolver_called = true;
+        EXPECT_EQ(handle.id(), "wire.graph");
+
+        Graph graph;
+        auto& interface = graph.interface;
+        const auto v0 = interface.add_vertex(vec3{0.0F, 0.0F, 0.0F});
+        const auto v1 = interface.add_vertex(vec3{1.0F, 0.0F, 0.0F});
+        static_cast<void>(interface.add_edge(v0, v1));
+        return graph;
+    };
+
+    Provider provider(mesh_resolver, {}, graph_resolver);
+    GraphHandle handle{std::string{"wire.graph"}};
+    provider.require_graph(handle);
+
+    EXPECT_TRUE(resolver_called);
+    const auto* record = provider.graph(handle);
+    ASSERT_NE(record, nullptr);
+    EXPECT_EQ(record->positions.size(), 2U);
+    EXPECT_EQ(record->indices.size(), 2U);
+    EXPECT_FLOAT_EQ(record->bounds.min[0], 0.0F);
+    EXPECT_FLOAT_EQ(record->bounds.max[0], 1.0F);
+}
+
+TEST(OpenGLRenderResourceProvider, CachesGraphsAfterFirstLoad)
+{
+    int resolver_count = 0;
+    auto mesh_resolver = [](const MeshHandle&) -> std::optional<SurfaceMesh> { return std::nullopt; };
+    auto graph_resolver = [&](const GraphHandle&) -> std::optional<Graph>
+    {
+        ++resolver_count;
+        Graph graph;
+        auto& interface = graph.interface;
+        const auto v0 = interface.add_vertex(vec3{0.0F, 0.0F, 0.0F});
+        const auto v1 = interface.add_vertex(vec3{0.0F, 1.0F, 0.0F});
+        static_cast<void>(interface.add_edge(v0, v1));
+        return graph;
+    };
+
+    Provider provider(mesh_resolver, {}, graph_resolver);
+    GraphHandle handle{std::string{"cached.graph"}};
+
+    provider.require_graph(handle);
+    provider.require_graph(handle);
+    provider.require_graph(handle);
+
+    EXPECT_EQ(resolver_count, 1);
+}
+
+TEST(OpenGLRenderResourceProvider, IgnoresEmptyGraphHandles)
+{
+    bool resolver_called = false;
+    auto mesh_resolver = [](const MeshHandle&) -> std::optional<SurfaceMesh> { return std::nullopt; };
+    auto graph_resolver = [&](const GraphHandle&) -> std::optional<Graph>
+    {
+        resolver_called = true;
+        return std::nullopt;
+    };
+
+    Provider provider(mesh_resolver, {}, graph_resolver);
+    GraphHandle empty_handle;
+
+    provider.require_graph(empty_handle);
+    EXPECT_FALSE(resolver_called);
+    EXPECT_EQ(provider.graph(empty_handle), nullptr);
 }

--- a/engine/runtime/src/application.cpp
+++ b/engine/runtime/src/application.cpp
@@ -90,6 +90,16 @@ namespace
                         {
                             return std::nullopt;
                         }
+                    },
+                    [](const engine::assets::PointCloudHandle&) -> std::optional<engine::geometry::PointCloud>
+                    {
+                        return std::nullopt;
+                    },
+                    nullptr,
+                    0,
+                    [](const engine::assets::GraphHandle&) -> std::optional<engine::geometry::Graph>
+                    {
+                        return std::nullopt;
                     });
                 return backend_instance;
             }

--- a/engine/runtime/tests/test_opengl_presentation_backend.cpp
+++ b/engine/runtime/tests/test_opengl_presentation_backend.cpp
@@ -67,6 +67,12 @@ TEST(RuntimePresentationBackend, OpenGLBackendExecutesFrameGraph)
         [](const engine::assets::PointCloudHandle&) -> std::optional<engine::geometry::PointCloud>
         {
             return std::nullopt;
+        },
+        nullptr,
+        0,
+        [](const engine::assets::GraphHandle&) -> std::optional<engine::geometry::Graph>
+        {
+            return std::nullopt;
         });
 
     engine::assets::ShaderHandle shader_handle{std::string{"runtime.shader"}};
@@ -113,7 +119,10 @@ TEST(RuntimePresentationBackend, OpenGLBackendConfiguresRetentionFrames)
             return std::nullopt;
         },
         nullptr,
-        3);
+        3,
+        [](const engine::assets::GraphHandle&) -> std::optional<engine::geometry::Graph> {
+            return std::nullopt;
+        });
 
     EXPECT_EQ(backend.resource_retention_frames(), 3U);
 

--- a/engine/tools/examples/geometry_viewer.cpp
+++ b/engine/tools/examples/geometry_viewer.cpp
@@ -32,6 +32,7 @@
 #include "engine/geometry/api.hpp"
 #include "engine/geometry/mesh/surface_mesh.hpp"
 #include "engine/geometry/mesh/surface_mesh_conversion.hpp"
+#include "engine/geometry/mesh/wireframe_graph.hpp"
 #include "engine/geometry/point_cloud/point_cloud.hpp"
 #include "engine/geometry/shapes/aabb.hpp"
 #include "engine/io/geometry_io.hpp"
@@ -121,6 +122,41 @@ namespace
 
     private:
         std::unordered_map<std::string, engine::geometry::SurfaceMesh> meshes_{};
+    };
+
+    class ProceduralGraphStorage
+    {
+    public:
+        void store(std::string identifier, engine::geometry::Graph graph)
+        {
+            graphs_.insert_or_assign(std::move(identifier), std::move(graph));
+        }
+
+        [[nodiscard]] bool contains(std::string_view identifier) const
+        {
+            return graphs_.find(std::string{identifier}) != graphs_.end();
+        }
+
+        [[nodiscard]] std::optional<engine::geometry::Graph> get(std::string_view identifier) const
+        {
+            if (const auto it = graphs_.find(std::string{identifier}); it != graphs_.end())
+            {
+                return it->second;
+            }
+            return std::nullopt;
+        }
+
+        [[nodiscard]] const engine::geometry::Graph* find(std::string_view identifier) const
+        {
+            if (const auto it = graphs_.find(std::string{identifier}); it != graphs_.end())
+            {
+                return &it->second;
+            }
+            return nullptr;
+        }
+
+    private:
+        std::unordered_map<std::string, engine::geometry::Graph> graphs_{};
     };
 
     class GeometryViewerApp : public engine::runtime::Application
@@ -218,8 +254,26 @@ namespace
                           return std::nullopt;
                       };
 
+                      auto graph_resolver = [this](const engine::assets::GraphHandle& handle)
+                          -> std::optional<engine::geometry::Graph> {
+                          if (handle.empty() || !graph_storage_)
+                          {
+                              return std::nullopt;
+                          }
+
+                          if (auto graph = graph_storage_->get(handle.id()))
+                          {
+                              return graph;
+                          }
+                          return std::nullopt;
+                      };
+
                       auto backend = std::make_shared<engine::rendering::backend::opengl::OpenGLPresentationBackend>(
-                          std::move(mesh_resolver), std::move(point_cloud_resolver));
+                          std::move(mesh_resolver),
+                          std::move(point_cloud_resolver),
+                          nullptr,
+                          0,
+                          std::move(graph_resolver));
                       backend_ = backend;
                       return backend;
                   };
@@ -366,7 +420,9 @@ namespace
         {
 #if ENGINE_ENABLE_RENDERING
             auto cube_mesh = engine::geometry::make_unit_cube();
-            mesh_storage_->store(std::string{kProceduralCubeId}, std::move(cube_mesh));
+            const std::string cube_id{std::string{kProceduralCubeId}};
+            cache_wireframe_graph(cube_id, cube_mesh);
+            mesh_storage_->store(cube_id, std::move(cube_mesh));
 
 #    if ENGINE_ENABLE_ASSETS
             material_validator_registration_ =
@@ -380,6 +436,16 @@ namespace
             mesh_validator_registration_ =
                 engine::assets::HandleValidatorRegistry::instance().register_mesh_validator(
                     [storage = mesh_storage_](const engine::assets::MeshHandle& handle) {
+                        if (!storage || handle.empty())
+                        {
+                            return false;
+                        }
+                        return storage->contains(handle.id());
+                    });
+
+            graph_validator_registration_ =
+                engine::assets::HandleValidatorRegistry::instance().register_graph_validator(
+                    [storage = graph_storage_](const engine::assets::GraphHandle& handle) {
                         if (!storage || handle.empty())
                         {
                             return false;
@@ -519,6 +585,7 @@ namespace
                 const auto& asset = mesh_cache_.load(descriptor);
                 auto surface_mesh = engine::geometry::mesh::build_surface_mesh_from_halfedge(asset.mesh.interface);
                 const std::string model_id = std::string{asset.descriptor.handle.id()};
+                cache_wireframe_graph(model_id, surface_mesh);
                 attach_render_geometry(model_id,
                     engine::rendering::components::RenderGeometry::from_mesh(
                         asset.descriptor.handle, default_material_),
@@ -614,10 +681,159 @@ namespace
             {
                 entity_local_bounds_.erase(entity);
             }
+
+            attach_wireframe_geometry_if_needed(identifier);
 #else
             (void)identifier;
             (void)geometry;
             (void)local_bounds;
+#endif
+        }
+
+        [[nodiscard]] static std::string make_wireframe_identifier(std::string_view identifier)
+        {
+            std::string result{identifier};
+            result += ".wireframe";
+            return result;
+        }
+
+        void cache_wireframe_graph(const std::string& identifier, const engine::geometry::SurfaceMesh& mesh)
+        {
+#if ENGINE_ENABLE_RENDERING
+            if (!graph_storage_)
+            {
+                return;
+            }
+
+            try
+            {
+                auto graph = engine::geometry::mesh::build_wireframe_graph(mesh);
+                graph_storage_->store(make_wireframe_identifier(identifier), std::move(graph));
+            }
+            catch (const std::exception& ex)
+            {
+                ENGINE_WARN("Failed to build wireframe graph for '{}': {}", identifier, ex.what());
+            }
+#else
+            (void)identifier;
+            (void)mesh;
+#endif
+        }
+
+        void attach_wireframe_geometry_if_needed(const std::string& identifier)
+        {
+#if ENGINE_ENABLE_RENDERING
+            if (wireframe_enabled_)
+            {
+                attach_wireframe_geometry(identifier);
+            }
+#else
+            (void)identifier;
+#endif
+        }
+
+        void attach_wireframe_geometry(const std::string& identifier)
+        {
+#if ENGINE_ENABLE_RENDERING
+            if (!wireframe_enabled_ || !graph_storage_)
+            {
+                return;
+            }
+
+            const auto graph_id = make_wireframe_identifier(identifier);
+            if (!graph_storage_->contains(graph_id))
+            {
+                return;
+            }
+
+            auto& registry = scene().registry();
+            entt::entity overlay = entt::null;
+            if (const auto it = wireframe_entities_.find(identifier); it == wireframe_entities_.end())
+            {
+                overlay = registry.create();
+                wireframe_entities_.emplace(identifier, overlay);
+                registry.emplace<engine::scene::components::Name>(overlay).value = graph_id;
+                registry.emplace<engine::scene::components::Hierarchy>(overlay);
+                registry.emplace<engine::scene::components::LocalTransform>(overlay);
+                registry.emplace<engine::scene::components::WorldTransform>(overlay);
+            }
+            else
+            {
+                overlay = it->second;
+            }
+
+            registry.emplace_or_replace<engine::rendering::components::RenderGeometry>(
+                overlay,
+                engine::rendering::components::RenderGeometry::from_graph(
+                    engine::assets::GraphHandle{graph_id},
+                    default_material_));
+
+            if (const auto base_it = render_entities_.find(identifier); base_it != render_entities_.end())
+            {
+                engine::scene::systems::set_parent(registry, overlay, base_it->second, true);
+                if (const auto bounds_it = entity_local_bounds_.find(base_it->second);
+                    bounds_it != entity_local_bounds_.end())
+                {
+                    entity_local_bounds_[overlay] = bounds_it->second;
+                }
+            }
+#else
+            (void)identifier;
+#endif
+        }
+
+        void remove_wireframe_overlay(const std::string& identifier)
+        {
+#if ENGINE_ENABLE_RENDERING
+            if (const auto it = wireframe_entities_.find(identifier); it != wireframe_entities_.end())
+            {
+                auto& registry = scene().registry();
+                const auto entity = it->second;
+                if (registry.valid(entity))
+                {
+                    registry.destroy(entity);
+                }
+                entity_local_bounds_.erase(entity);
+                wireframe_entities_.erase(it);
+            }
+#else
+            (void)identifier;
+#endif
+        }
+
+        void remove_all_wireframe_overlays()
+        {
+#if ENGINE_ENABLE_RENDERING
+            auto& registry = scene().registry();
+            for (const auto& [_, entity] : wireframe_entities_)
+            {
+                if (registry.valid(entity))
+                {
+                    registry.destroy(entity);
+                }
+                entity_local_bounds_.erase(entity);
+            }
+            wireframe_entities_.clear();
+#endif
+        }
+
+        void toggle_wireframe_mode()
+        {
+#if ENGINE_ENABLE_RENDERING
+            wireframe_enabled_ = !wireframe_enabled_;
+            if (wireframe_enabled_)
+            {
+                for (const auto& [identifier, _] : render_entities_)
+                {
+                    attach_wireframe_geometry(identifier);
+                }
+                ENGINE_INFO("Wireframe overlay enabled");
+            }
+            else
+            {
+                remove_all_wireframe_overlays();
+                ENGINE_INFO("Wireframe overlay disabled");
+            }
 #endif
         }
 
@@ -810,6 +1026,11 @@ namespace
                 delete_last_model();
             }
 
+            if (allow_keyboard_input && input_state.was_key_pressed(engine::platform::input::Key::F))
+            {
+                toggle_wireframe_mode();
+            }
+
             if (input_state.was_key_pressed(engine::platform::input::Key::G) && panel_bridge_)
             {
                 panels_visible_ = !panels_visible_;
@@ -878,6 +1099,7 @@ namespace
                         registry.remove<engine::rendering::components::RenderGeometry>(entity);
                         ENGINE_INFO("Cube hidden");
                     }
+                    remove_wireframe_overlay(cube_id);
                 }
             }
 #endif
@@ -895,6 +1117,7 @@ namespace
             // Get the last loaded model (LIFO - stack order)
             const std::string model_id = loaded_models_order_.back();
             loaded_models_order_.pop_back();
+            remove_wireframe_overlay(model_id);
 
             auto& registry = scene().registry();
             if (const auto it = render_entities_.find(model_id); it != render_entities_.end())
@@ -1769,8 +1992,10 @@ namespace
 
         WindowExtent window_extent_{};
         std::shared_ptr<ProceduralMeshStorage> mesh_storage_{std::make_shared<ProceduralMeshStorage>()};
+        std::shared_ptr<ProceduralGraphStorage> graph_storage_{std::make_shared<ProceduralGraphStorage>()};
         std::shared_ptr<void> mesh_validator_registration_{};
         std::shared_ptr<void> material_validator_registration_{};
+        std::shared_ptr<void> graph_validator_registration_{};
 #if ENGINE_ENABLE_ASSETS
         engine::assets::MeshCache mesh_cache_{};
         engine::assets::PointCloudCache point_cloud_cache_{};
@@ -1802,6 +2027,7 @@ namespace
         bool selection_drag_threshold_exceeded_{false};
 #endif
         std::unordered_map<std::string, entt::entity> render_entities_{};
+        std::unordered_map<std::string, entt::entity> wireframe_entities_{};
         std::vector<std::string> loaded_models_order_{}; // Track loaded models in creation order (excluding cube)
         bool cube_visible_{true}; // Toggle state for default cube
         engine::assets::MaterialHandle default_material_{std::string{"geometry_viewer.material.default"}};
@@ -1810,6 +2036,7 @@ namespace
         engine::math::vec2 last_cursor_pos_{0.0f, 0.0f};
         int fps_frame_count_{0};
         double fps_time_accumulator_{0.0};
+        bool wireframe_enabled_{false};
     };
 } // namespace
 


### PR DESCRIPTION
## Summary
- integrate graph caching, resolver wiring, and wireframe overlays into the geometry viewer so meshes can be drawn as line graphs on demand
- document the new workflow in the geometry viewer guide and rendering module README
- extend the OpenGL render resource provider with graph support plus unit tests covering graph uploads, caching, and empty handles

## Testing
- `cmake --preset linux-gcc-debug`
- `cmake --build --preset linux-gcc-debug --target engine_geometry_tests engine_rendering_tests`
- `ctest --preset linux-gcc-debug -R engine_geometry_tests`
- `ctest --preset linux-gcc-debug -R engine_rendering_tests`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9804b6e88320846aa36b7f845424)