### PR TITLE
Add sync script to generate TODO.md and DONE.md from hybrid backlog metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Claude Workflow Notes
+
+## TODO.md / DONE.md Policy
+
+`TODO.md` and `DONE.md` are generated artefacts:
+
+- `TODO.md` contains only active backlog work (`new`, `ready`, `in_progress`, `review`).
+- `DONE.md` contains completed backlog history (`done`, `archived`).
+
+Update both files by running:
+
+```bash
+python -m scripts.workflow.sync_todo_done
+```
+
+This does **not** run automatically on every backlog edit unless you wire the command into your local hooks or CI workflow.

--- a/DONE.md
+++ b/DONE.md
@@ -1,0 +1,45 @@
+# DONE
+
+Completed backlog history (done and archived items).
+
+_Generated automatically by `python -m scripts.workflow.sync_todo_done` on 2026-02-26T09:33:27+00:00._
+
+## done
+
+- [999] Fix Geometry Viewer Black Screen - Enable Cube Rendering and Camera Controls (priority: P0, owner: rendering-lead) — `hybrid_workflow/backlog/999-fix-geometry-viewer-rendering.md`
+- [BF-001] Fix runtime module compilation errors (priority: P0, owner: copilot) — `hybrid_workflow/backlog/archive/BF-001-fix-runtime-compilation-errors.md`
+- [RE-430] Implement WASD first-person camera movement controller (priority: P1, owner: agent) — `hybrid_workflow/backlog/archive/RE-430-wasd-camera-controller.md`
+- [RG-450] Modular render pipeline planner (priority: P1, owner: rendering-lead) — `hybrid_workflow/backlog/archive/RG-450-modular-render-pipeline.md`
+- [RG-450-A] Node descriptor API design (priority: P1, owner: rendering-lead) — `hybrid_workflow/backlog/archive/RG-450-A-node-descriptor-api.md`
+- [RG-501] Frame graph compilation cache (priority: P1, owner: rendering-systems) — `hybrid_workflow/backlog/archive/RG-501-frame-graph-compilation-cache.md`
+- [RG-502] Command buffer pooling and trimming (priority: P1, owner: rendering-systems) — `hybrid_workflow/backlog/archive/RG-502-command-buffer-pooling.md`
+- [RG-505] Async resource streaming for GPU providers (priority: P1, owner: rendering-runtime) — `hybrid_workflow/backlog/RG-505-async-resource-streaming.md`
+- [RT-410] Runtime stage planner & presentation loop (priority: P1, owner: runtime-lead) — `hybrid_workflow/backlog/archive/RT-410-runtime-stage-planner.md`
+- [RT-410-A] Stage planner API design (priority: P1, owner: runtime-lead) — `hybrid_workflow/backlog/archive/RT-410-A-stage-planner-api.md`
+- [T-0119] Command encoder integration (priority: P1, owner: rendering-lead) — `hybrid_workflow/backlog/archive/T-0119-command-encoder-integration.md`
+- [T-0120] GPU resource provider completion (priority: P1, owner: rendering-lead) — `hybrid_workflow/backlog/archive/T-0120-gpu-resource-provider.md`
+- [TL-315] Selection engine and hit-testing pipeline (priority: P1, owner: tools-lead) — `hybrid_workflow/backlog/archive/TL-315-selection-engine-and-hit-testing.md`
+- [RG-503] Frame-graph barrier optimization & batching (priority: P2, owner: rendering-systems) — `hybrid_workflow/backlog/archive/RG-503-barrier-optimizer.md`
+- [RG-504] GPU timeline queries & profiling integration (priority: P2, owner: rendering-telemetry) — `hybrid_workflow/backlog/archive/RG-504-gpu-profiler.md`
+- [TL-310] Editor foundations & tooling enablement (priority: P2, owner: tools-lead) — `hybrid_workflow/backlog/archive/TL-310-editor-foundations.md`
+- [TL-310-2a] Application ↔ PresentationBackend Integration (priority: P2, owner: tools-lead) — `hybrid_workflow/backlog/archive/TL-310-2a-application-presentation-integration.md`
+- [TL-311] Scene hierarchy diagnostic panel (priority: P2, owner: tools-lead) — `hybrid_workflow/backlog/archive/TL-311-scene-hierarchy-panel.md`
+- [TL-313] Asset browser panel for editor workflows (priority: P2, owner: tools-lead) — `hybrid_workflow/backlog/archive/TL-313-asset-browser-panel.md`
+- [TL-341] Add next-action summary to hybrid status reporter (priority: P2, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-341-next-action-summary.md`
+- [TL-345] Hybrid status reporter relates_to filter (priority: P2, owner: tools-devrel) — `hybrid_workflow/backlog/archive/TL-345-hybrid-status-relates-to-filter.md`
+- [ANALYSIS-001] Engine Tools Usage Analysis - Hybrid Workflow Coverage (priority: P3, owner: agent-orchestrator) — `hybrid_workflow/backlog/archive/TOOLS_USAGE_ANALYSIS.md`
+- [DC-050] Migrate workflow to hybrid model (priority: P3, owner: agent-orchestrator) — `hybrid_workflow/backlog/archive/DC-050-workflow-migration.md`
+- [TL-320] Task status dashboard automation (priority: P3, owner: tools-lead) — `hybrid_workflow/backlog/archive/TL-320-task-dashboard.md`
+- [TL-330] Add blocked filter to task status CLI (priority: P3, owner: docs-automation) — `hybrid_workflow/backlog/archive/TL-330-task-status-blocked-filter.md`
+- [TL-331] Hybrid status reporter JSON export (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-331-hybrid-status-json.md`
+- [TL-332] Task status CLI multiline metadata parsing (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-332-task-status-multiline-metadata.md`
+- [TL-340] Add unblocked filter to task status CLI (priority: P3, owner: docs-automation) — `hybrid_workflow/backlog/archive/TL-340-task-status-unblocked-filter.md`
+- [TL-342] Hybrid status reporter owner filter (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-342-hybrid-status-owner-filter.md`
+- [TL-343] Task status CLI owner filter (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-343-task-status-owner-filter.md`
+- [TL-344] Next-actions guidance for empty ready queue (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-344-next-actions-guidance.md`
+- [TL-346] Next-actions filter support in hybrid status reporter (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-346-next-actions-filter-support.md`
+- [TL-347] Add next-actions helper to task status CLI (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-347-task-status-next-actions.md`
+- [TL-348] Task status CLI JSON output (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-348-task-status-json-output.md`
+- [TL-349] Task-status search covers blocked_on metadata (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-349-task-status-blocked-search.md`
+- [TL-350] Add link filter to hybrid workflow task status CLIs (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-350-task-status-link-filter.md`
+- [TL-351] Add blocked_on dependency filter to hybrid workflow task CLIs (priority: P3, owner: docs-devrel) — `hybrid_workflow/backlog/archive/TL-351-task-status-blocked-on-filter.md`

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,17 @@
+# TODO
+
+Active backlog work only (items not yet completed).
+
+_Generated automatically by `python -m scripts.workflow.sync_todo_done` on 2026-02-26T09:33:27+00:00._
+
+## in_progress
+
+- [AI-004] Kickoff brief readiness (priority: P0, owner: agent-orchestrator) — `hybrid_workflow/backlog/AI-004-kickoff-brief.md`
+- [TL-316] Vertex, edge, and face selection for geometry entities (priority: P1, owner: geometry) — `hybrid_workflow/backlog/TL-316-subentity-component-selection.md`
+- [TL-317] Outline rendering for selected entities (priority: P1, owner: unassigned) — `hybrid_workflow/backlog/TL-317-selected-entity-outline-rendering.md`
+- [PM-510] Weekly GPU integration demos (priority: P2, owner: agent-orchestrator) — `hybrid_workflow/backlog/PM-510-weekly-integration-demos.md`
+
+## review
+
+- [TL-312] Performance metrics and profiler panel (priority: P2, owner: tools-lead) — `hybrid_workflow/backlog/TL-312-performance-metrics-panel.md`
+- [TL-314] Telemetry visualization panel for runtime diagnostics (priority: P2, owner: tools-lead) — `hybrid_workflow/backlog/TL-314-telemetry-visualization-panel.md`

--- a/hybrid_workflow/README.md
+++ b/hybrid_workflow/README.md
@@ -198,6 +198,9 @@ python -m scripts.workflow.report_hybrid_status
 # Machine-readable summary
 python -m scripts.workflow.report_hybrid_status --format json
 
+# Refresh root TODO.md (active) and DONE.md (completed history)
+python -m scripts.workflow.sync_todo_done
+
 # Filter by roadmap bundle metadata
 python -m scripts.workflow.report_hybrid_status --relates-to bundle:C
 python -m scripts.workflow.report_hybrid_status --relates-to bundle:A bundle:D

--- a/scripts/tests/test_sync_todo_done.py
+++ b/scripts/tests/test_sync_todo_done.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.workflow import sync_todo_done
+
+
+def test_sync_todo_done_writes_expected_sections(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    backlog_root = repo_root / "hybrid_workflow" / "backlog"
+    archive_root = backlog_root / "archive"
+    archive_root.mkdir(parents=True)
+
+    (backlog_root / "TL-100-active.md").write_text(
+        """---
+id: TL-100
+title: Active task
+status: in_progress
+priority: P1
+owner: tools
+---
+""",
+        encoding="utf-8",
+    )
+    (archive_root / "TL-200-done.md").write_text(
+        """---
+id: TL-200
+title: Done task
+status: archived
+priority: P2
+owner: docs
+---
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sync_todo_done, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(sync_todo_done, "TODO_PATH", repo_root / "TODO.md")
+    monkeypatch.setattr(sync_todo_done, "DONE_PATH", repo_root / "DONE.md")
+    monkeypatch.setattr(sync_todo_done.rhs, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(sync_todo_done.rhs, "BACKLOG_ROOT", backlog_root)
+
+    sync_todo_done.sync_todo_done()
+
+    todo_text = (repo_root / "TODO.md").read_text(encoding="utf-8")
+    done_text = (repo_root / "DONE.md").read_text(encoding="utf-8")
+
+    assert "# TODO" in todo_text
+    assert "TL-100" in todo_text
+    assert "TL-200" not in todo_text
+
+    assert "# DONE" in done_text
+    assert "TL-200" in done_text
+    assert "TL-100" not in done_text

--- a/scripts/workflow/sync_todo_done.py
+++ b/scripts/workflow/sync_todo_done.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Synchronise root TODO.md and DONE.md from hybrid workflow backlog metadata."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from scripts.workflow import report_hybrid_status as rhs
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TODO_PATH = REPO_ROOT / "TODO.md"
+DONE_PATH = REPO_ROOT / "DONE.md"
+
+ACTIVE_STATUSES: tuple[str, ...] = ("new", "ready", "in_progress", "review")
+DONE_STATUSES: tuple[str, ...] = ("done", "archived")
+
+
+@dataclass(frozen=True)
+class BacklogItem:
+    identifier: str
+    title: str
+    status: str
+    priority: str
+    owner: str
+    relative_path: str
+
+
+
+def _to_items(tasks: Iterable[rhs.TaskMetadata]) -> list[BacklogItem]:
+    items: list[BacklogItem] = []
+    for task in tasks:
+        items.append(
+            BacklogItem(
+                identifier=task.identifier,
+                title=task.title,
+                status=task.status,
+                priority=task.priority,
+                owner=task.owner,
+                relative_path=str(task.relative_path),
+            )
+        )
+    return items
+
+
+def _status_rank(status: str) -> int:
+    return rhs.STATUS_ORDER.get(status, len(rhs.STATUS_ORDER))
+
+
+def _priority_rank(priority: str) -> int:
+    return rhs.PRIORITY_ORDER.get(priority, len(rhs.PRIORITY_ORDER))
+
+
+def _sort_key(item: BacklogItem) -> tuple[int, int, str]:
+    return (_status_rank(item.status), _priority_rank(item.priority), item.identifier)
+
+
+def _render(title: str, subtitle: str, items: Sequence[BacklogItem], statuses: Sequence[str]) -> str:
+    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    grouped: dict[str, list[BacklogItem]] = defaultdict(list)
+    for item in sorted(items, key=_sort_key):
+        grouped[item.status].append(item)
+
+    lines: list[str] = [
+        f"# {title}",
+        "",
+        subtitle,
+        "",
+        f"_Generated automatically by `python -m scripts.workflow.sync_todo_done` on {generated_at}._",
+        "",
+    ]
+
+    if not items:
+        lines.extend(["No entries currently match this view.", ""])
+        return "\n".join(lines)
+
+    for status in statuses:
+        section_items = grouped.get(status, [])
+        if not section_items:
+            continue
+        lines.extend([f"## {status}", ""])
+        for item in section_items:
+            lines.append(
+                f"- [{item.identifier}] {item.title} "
+                f"(priority: {item.priority}, owner: {item.owner}) "
+                f"— `{item.relative_path}`"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def sync_todo_done() -> tuple[Path, Path]:
+    active_tasks = rhs.collect_tasks(include_archived=False)
+    historical_tasks = rhs.collect_tasks(include_archived=True)
+
+    active_items = [item for item in _to_items(active_tasks) if item.status in ACTIVE_STATUSES]
+    done_items = [item for item in _to_items(historical_tasks) if item.status in DONE_STATUSES]
+
+    TODO_PATH.write_text(
+        _render(
+            "TODO",
+            "Active backlog work only (items not yet completed).",
+            active_items,
+            ACTIVE_STATUSES,
+        ),
+        encoding="utf-8",
+    )
+    DONE_PATH.write_text(
+        _render(
+            "DONE",
+            "Completed backlog history (done and archived items).",
+            done_items,
+            DONE_STATUSES,
+        ),
+        encoding="utf-8",
+    )
+    return TODO_PATH, DONE_PATH
+
+
+def main() -> int:
+    todo_path, done_path = sync_todo_done()
+    print(f"Updated {todo_path.relative_to(REPO_ROOT)}")
+    print(f"Updated {done_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Make `TODO.md` and `DONE.md` deterministic and reflect the canonical hybrid backlog frontmatter so active work and completed history are not diverging by manual edits. 
- Formalise the policy that `TODO.md` contains only active statuses (`new`, `ready`, `in_progress`, `review`) and `DONE.md` contains completed history (`done`, `archived`).
- Provide an explicit, reproducible command suitable for local use or CI hooks so the repository can keep those generated artefacts in sync with backlog metadata.

### Description
- Added `scripts/workflow/sync_todo_done.py` which collects task metadata via `scripts.workflow.report_hybrid_status` and emits `TODO.md` (active tasks) and `DONE.md` (done/archived history). 
- Added `scripts/tests/test_sync_todo_done.py` to validate that active items appear only in `TODO.md` and completed items appear only in `DONE.md`.
- Added `CLAUDE.md` documenting the TODO/DONE policy and the sync command, and updated `hybrid_workflow/README.md` to include the `python -m scripts.workflow.sync_todo_done` example in the automation examples. 
- Generated `TODO.md` and `DONE.md` from the current backlog snapshot (these files are now present in the repo as generated outputs).

### Testing
- Ran the sync command `python -m scripts.workflow.sync_todo_done` to produce `TODO.md` and `DONE.md` which updated successfully. 
- Executed unit tests with `pytest scripts/tests/test_sync_todo_done.py scripts/tests/test_report_hybrid_status.py` and observed all tests pass (`30 passed`).
- Ran documentation validation with `python scripts/validate_docs.py` which reported all documentation links resolved successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0130fcc448320944f2994f0d96bd6)